### PR TITLE
Add more Object Literal

### DIFF
--- a/Sources/ASTNodeModule/Expr/TSObjectExpr.swift
+++ b/Sources/ASTNodeModule/Expr/TSObjectExpr.swift
@@ -1,11 +1,8 @@
 public final class TSObjectExpr: _TSExpr {
-    public struct Field {
-        public init(name: String, value: any TSExpr) {
-            self.name = name
-            self.value = value
-        }
-        public var name: String
-        public var value: any TSExpr
+    public enum Field {
+        case named(name: String, value: any TSExpr)
+        case namedWithVariable(varName: String)
+        case method(TSMethodDecl)
     }
 
     public init(
@@ -23,11 +20,25 @@ public final class TSObjectExpr: _TSExpr {
         get { _fields }
         set {
             for field in _fields {
-                field.value.setParent(nil)
+                switch field {
+                case .named(_, let value):
+                    value.setParent(nil)
+                case .namedWithVariable:
+                    break
+                case .method(let decl):
+                    decl.setParent(nil)
+                }
             }
             _fields = newValue
             for field in newValue {
-                field.value.setParent(self)
+                switch field {
+                case .named(_, let value):
+                    value.setParent(self)
+                case .namedWithVariable:
+                    break
+                case .method(let decl):
+                    decl.setParent(self)
+                }
             }
         }
     }

--- a/Sources/ASTNodeModule/Expr/TSObjectExpr.swift
+++ b/Sources/ASTNodeModule/Expr/TSObjectExpr.swift
@@ -1,7 +1,8 @@
 public final class TSObjectExpr: _TSExpr {
     public enum Field {
         case named(name: String, value: any TSExpr)
-        case namedWithVariable(varName: String)
+        case shorthandPropertyNames(name: String)
+        case computedPropertyNames(name: any TSExpr, value: any TSExpr)
         case method(TSMethodDecl)
     }
 
@@ -23,8 +24,11 @@ public final class TSObjectExpr: _TSExpr {
                 switch field {
                 case .named(_, let value):
                     value.setParent(nil)
-                case .namedWithVariable:
+                case .shorthandPropertyNames:
                     break
+                case .computedPropertyNames(let name, let value):
+                    name.setParent(nil)
+                    value.setParent(nil)
                 case .method(let decl):
                     decl.setParent(nil)
                 }
@@ -34,8 +38,11 @@ public final class TSObjectExpr: _TSExpr {
                 switch field {
                 case .named(_, let value):
                     value.setParent(self)
-                case .namedWithVariable:
+                case .shorthandPropertyNames:
                     break
+                case .computedPropertyNames(let name, let value):
+                    name.setParent(self)
+                    value.setParent(self)
                 case .method(let decl):
                     decl.setParent(self)
                 }

--- a/Sources/TypeScriptAST/Component/ASTVisitor.swift
+++ b/Sources/TypeScriptAST/Component/ASTVisitor.swift
@@ -33,8 +33,11 @@ open class ASTVisitor {
         switch field {
         case .named(_, let value):
             walk(value)
-        case .namedWithVariable:
+        case .shorthandPropertyNames:
             break
+        case .computedPropertyNames(let name, let value):
+            walk(name)
+            walk(value)
         case .method(let decl):
             walk(decl)
         }

--- a/Sources/TypeScriptAST/Component/ASTVisitor.swift
+++ b/Sources/TypeScriptAST/Component/ASTVisitor.swift
@@ -30,7 +30,14 @@ open class ASTVisitor {
     }
 
     private func walk(field: TSObjectExpr.Field) {
-        walk(field.value)
+        switch field {
+        case .named(_, let value):
+            walk(value)
+        case .namedWithVariable:
+            break
+        case .method(let decl):
+            walk(decl)
+        }
     }
 
     private func walk(fields: [TSObjectExpr.Field]) {

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -491,9 +491,16 @@ public final class ASTPrinter: ASTVisitor {
     }
 
     private func write(field: TSObjectExpr.Field) {
-        printer.write(field.name)
-        printer.write(": ")
-        walk(field.value)
+        switch field {
+        case .named(let name, let value):
+            printer.write(name)
+            printer.write(": ")
+            walk(value)
+        case .namedWithVariable(let varName):
+            printer.write(varName)
+        case .method(let decl):
+            walk(decl)
+        }
     }
 
     public override func visit(paren: TSParenExpr) -> Bool {

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -496,8 +496,14 @@ public final class ASTPrinter: ASTVisitor {
             printer.write(name)
             printer.write(": ")
             walk(value)
-        case .namedWithVariable(let varName):
-            printer.write(varName)
+        case .shorthandPropertyNames(let name):
+            printer.write(name)
+        case .computedPropertyNames(let name, let value):
+            printer.write("[")
+            walk(name)
+            printer.write("]")
+            printer.write(": ")
+            walk(value)
         case .method(let decl):
             walk(decl)
         }

--- a/Tests/TypeScriptASTTests/PrintExprTests.swift
+++ b/Tests/TypeScriptASTTests/PrintExprTests.swift
@@ -245,13 +245,17 @@ final class PrintExprTests: TestCaseBase {
         assertPrint(
             TSObjectExpr([
                 .named(name: "a", value: TSIdentExpr.true),
-                .namedWithVariable(varName: "b"),
+                .shorthandPropertyNames(name: "b"),
+                .computedPropertyNames(name: TSInfixOperatorExpr(
+                    TSIdentExpr("a"), "+", TSNumberLiteralExpr(42)
+                ), value: TSIdentExpr.true),
                 .method(.init(name: "c", params: [], body: TSBlockStmt([])))
             ]),
             """
             {
                 a: true,
                 b,
+                [a + 42]: true,
                 c() {}
             }
             """

--- a/Tests/TypeScriptASTTests/PrintExprTests.swift
+++ b/Tests/TypeScriptASTTests/PrintExprTests.swift
@@ -244,11 +244,15 @@ final class PrintExprTests: TestCaseBase {
 
         assertPrint(
             TSObjectExpr([
-                .init(name: "a", value: TSIdentExpr.true)
+                .named(name: "a", value: TSIdentExpr.true),
+                .namedWithVariable(varName: "b"),
+                .method(.init(name: "c", params: [], body: TSBlockStmt([])))
             ]),
             """
             {
-                a: true
+                a: true,
+                b,
+                c() {}
             }
             """
         )

--- a/Tests/TypeScriptASTTests/ScanDependencyTests.swift
+++ b/Tests/TypeScriptASTTests/ScanDependencyTests.swift
@@ -59,9 +59,9 @@ final class ScanDependencyTests: TestCaseBase {
                 body: TSBlockStmt([
                     TSReturnStmt(
                         TSObjectExpr([
-                            .init(name: "a", value: TSStringLiteralExpr("a")),
-                            .init(name: "b", value: TSIdentExpr("t")),
-                            .init(name: "c", value: TSCallExpr(
+                            .named(name: "a", value: TSStringLiteralExpr("a")),
+                            .named(name: "b", value: TSIdentExpr("t")),
+                            .named(name: "c", value: TSCallExpr(
                                 callee: TSIdentExpr("g"), args: [])
                             )
                         ])


### PR DESCRIPTION
オブジェクトリテラルについて、バリエーションを増やします。
現状は名前つきプロパティのみの対応でしたが、新たに

- Shorthand property names
- Computed property names
- Method

に対応します。
以下のようなオブジェクトリテラルが表現可能になります。

```ts
const foo =  {
    a: true,
    b,
    [a + 42]: true,
    c() {}
}
```