### PR TITLE
Add TypeScript Utility types

### DIFF
--- a/Sources/TypeScriptAST/Component/SymbolTable.swift
+++ b/Sources/TypeScriptAST/Component/SymbolTable.swift
@@ -27,7 +27,30 @@ public struct SymbolTable {
         "this",
         "Promise",
         "Error",
-        "Date"
+        "Date",
+
+        // TypeScript Utility types
+        "Awaited",
+        "Partial",
+        "Required",
+        "Readonly",
+        "Record",
+        "Pick",
+        "Omit",
+        "Exclude",
+        "Extract",
+        "NonNullable",
+        "Parameters",
+        "ConstructorParameters",
+        "ReturnType",
+        "InstanceType",
+        "ThisParameterType",
+        "OmitThisParameter",
+        "ThisType",
+        "Uppercase",
+        "Lowercase",
+        "Capitalize",
+        "Uncapitalize",
     ]
 
     public var table: [String: File] = [:]

--- a/Tests/TypeScriptASTTests/AutoImportTests.swift
+++ b/Tests/TypeScriptASTTests/AutoImportTests.swift
@@ -4,11 +4,11 @@ import TypeScriptAST
 final class AutoImportTests: TestCaseBase {
     func testAutoImport() throws {
         let s = TSSourceFile([
-            TSTypeDecl(modifiers: [.export], name: "S", type: TSObjectType([]))
+            TSTypeDecl(modifiers: [.export], name: "S", type: TSIdentType("Record", genericArgs: [TSIdentType("string"), TSIdentType("number")]))
         ])
         assertPrint(
             s, """
-            export type S = {};
+            export type S = Record<string, number>;
 
             """
         )


### PR DESCRIPTION
自動インポート機能の解決時に、TS標準で提供されているユーティリティタイプが含まれる際、 `unknown symbol` エラーが出てしまう問題を解決します。

例:

```
Error: unknown symbol: Record
```


https://www.typescriptlang.org/docs/handbook/utility-types.html
を参考に、ユーティリティタイプを標準ライブラリの型として登録しました