### PR TITLE
Add Template literal

### DIFF
--- a/Sources/ASTNodeModule/Decl/TSDeclModifier.swift
+++ b/Sources/ASTNodeModule/Decl/TSDeclModifier.swift
@@ -4,4 +4,5 @@ public enum TSDeclModifier: String {
     case `private`
     case protected
     case async
+    case readonly
 }

--- a/Sources/ASTNodeModule/Expr/TSExpr.swift
+++ b/Sources/ASTNodeModule/Expr/TSExpr.swift
@@ -22,5 +22,6 @@ extension TSExpr {
     public var asPostfixOperator: TSPostfixOperatorExpr? { self as? TSPostfixOperatorExpr }
     public var asPrefixOperator: TSPrefixOperatorExpr? { self as? TSPrefixOperatorExpr }
     public var asStringLiteral: TSStringLiteralExpr? { self as? TSStringLiteralExpr }
+    public var asTemplateLiteral: TSTemplateLiteralExpr? { self as? TSTemplateLiteralExpr }
     public var asSubscript: TSSubscriptExpr? { self as? TSSubscriptExpr }
 }

--- a/Sources/ASTNodeModule/Expr/TSTemplateLiteralExpr.swift
+++ b/Sources/ASTNodeModule/Expr/TSTemplateLiteralExpr.swift
@@ -1,0 +1,70 @@
+public final class TSTemplateLiteralExpr: _TSExpr {
+    public enum Fragment {
+        case literal(String)
+        case expr(any TSExpr)
+    }
+
+    public struct StringInterpolation {
+        var fragments: [Fragment]
+    }
+
+    public init(tag: String? = nil, _ stringInterpolation: StringInterpolation) {
+        self.tag = tag
+        self.fragments = stringInterpolation.fragments
+        self.substitutions = fragments.substitutions
+    }
+
+    public private(set) unowned var parent: (any ASTNode)?
+    internal func _setParent(_ newValue: (any ASTNode)?) {
+        parent = newValue
+    }
+
+    public var tag: String?
+    public var fragments: [Fragment] {
+        didSet {
+            substitutions = fragments.substitutions
+        }
+    }
+    @AnyTSExprArrayStorage public private(set) var substitutions: [any TSExpr]
+}
+
+extension TSTemplateLiteralExpr.StringInterpolation: ExpressibleByStringLiteral {
+    public init(stringLiteral value: StringLiteralType) {
+        fragments = [.literal(value)]
+    }
+}
+
+extension TSTemplateLiteralExpr.StringInterpolation: ExpressibleByStringInterpolation {
+    public init(stringInterpolation: Self) {
+        fragments = stringInterpolation.fragments
+    }
+}
+
+extension TSTemplateLiteralExpr.StringInterpolation: StringInterpolationProtocol {
+    public init(literalCapacity: Int, interpolationCount: Int) {
+        self.fragments = []
+    }
+
+    public mutating func appendLiteral(_ literal: String) {
+        fragments.append(.literal(literal))
+    }
+
+    public mutating func appendInterpolation(_ expr: any TSExpr) {
+        fragments.append(.expr(expr))
+    }
+
+    public mutating func appendInterpolation(ident: String) {
+        fragments.append(.expr(TSIdentExpr(ident)))
+    }
+}
+
+extension [TSTemplateLiteralExpr.Fragment] {
+    public var substitutions: [any TSExpr] {
+        compactMap { elem in
+            if case .expr(let expr) = elem {
+                return expr
+            }
+            return nil
+        }
+    }
+}

--- a/Sources/ASTNodeModule/Expr/TSTemplateLiteralExpr.swift
+++ b/Sources/ASTNodeModule/Expr/TSTemplateLiteralExpr.swift
@@ -42,7 +42,7 @@ extension TSTemplateLiteralExpr.StringInterpolation: ExpressibleByStringInterpol
 
 extension TSTemplateLiteralExpr.StringInterpolation: StringInterpolationProtocol {
     public init(literalCapacity: Int, interpolationCount: Int) {
-        self.fragments = []
+        fragments = []
     }
 
     public mutating func appendLiteral(_ literal: String) {

--- a/Sources/TypeScriptAST/Component/ASTVisitor.swift
+++ b/Sources/TypeScriptAST/Component/ASTVisitor.swift
@@ -114,6 +114,8 @@ open class ASTVisitor {
     open func visitPost(prefixOperator: TSPrefixOperatorExpr) {}
     open func visit(stringLiteral: TSStringLiteralExpr) -> Bool { defaultVisitResult }
     open func visitPost(stringLiteral: TSStringLiteralExpr) {}
+    open func visit(templateLiteral: TSTemplateLiteralExpr) -> Bool { defaultVisitResult }
+    open func visitPost(templateLiteral: TSTemplateLiteralExpr) {}
     open func visit(subscript: TSSubscriptExpr) -> Bool { defaultVisitResult }
     open func visitPost(subscript: TSSubscriptExpr) {}
 
@@ -190,6 +192,7 @@ open class ASTVisitor {
         case let x as TSPostfixOperatorExpr: visitImpl(postfixOperator: x)
         case let x as TSPrefixOperatorExpr: visitImpl(prefixOperator: x)
         case let x as TSStringLiteralExpr: visitImpl(stringLiteral: x)
+        case let x as TSTemplateLiteralExpr: visitImpl(templateLiteral: x)
         case let x as TSSubscriptExpr: visitImpl(subscript: x)
         case let x as TSBlockStmt: visitImpl(block: x)
         case let x as TSCaseStmt: visitImpl(case: x)
@@ -387,6 +390,12 @@ open class ASTVisitor {
     private func visitImpl(stringLiteral: TSStringLiteralExpr) {
         guard visit(stringLiteral: stringLiteral) else { return }
         visitPost(stringLiteral: stringLiteral)
+    }
+
+    private func visitImpl(templateLiteral: TSTemplateLiteralExpr) {
+        guard visit(templateLiteral: templateLiteral) else { return }
+        walk(templateLiteral.substitutions)
+        visitPost(templateLiteral: templateLiteral)
     }
 
     private func visitImpl(subscript: TSSubscriptExpr) {

--- a/Sources/TypeScriptAST/Component/SymbolTable.swift
+++ b/Sources/TypeScriptAST/Component/SymbolTable.swift
@@ -25,6 +25,7 @@ public struct SymbolTable {
         "number",
         "string",
         "this",
+        "super",
         "Promise",
         "Error",
         "Date",

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -535,6 +535,25 @@ public final class ASTPrinter: ASTVisitor {
         return false
     }
 
+    public override func visit(templateLiteral: TSTemplateLiteralExpr) -> Bool {
+        if let tag = templateLiteral.tag {
+            printer.write(tag)
+        }
+        printer.write("`")
+        for fragment in templateLiteral.fragments {
+            switch fragment {
+            case .literal(let literal):
+                printer.write(literal)
+            case .expr(let expr):
+                printer.write("${")
+                walk(expr)
+                printer.write("}")
+            }
+        }
+        printer.write("`")
+        return false
+    }
+
     public override func visit(subscript: TSSubscriptExpr) -> Bool {
         walk(`subscript`.base)
         printer.write("[")

--- a/Tests/TypeScriptASTTests/PrintExprTests.swift
+++ b/Tests/TypeScriptASTTests/PrintExprTests.swift
@@ -166,6 +166,22 @@ final class PrintExprTests: TestCaseBase {
         )
     }
 
+    func testTemplateLiteral() throws {
+        assertPrint(
+            TSTemplateLiteralExpr("string text \(TSIdentExpr("foo")) string text"),
+            #"""
+            `string text ${foo} string text`
+            """#
+        )
+
+        assertPrint(
+            TSTemplateLiteralExpr(tag: "css", "\(ident: "foo")string\(ident: "bar")"),
+            #"""
+            css`${foo}string${bar}`
+            """#
+        )
+    }
+
     func testIdent() throws {
         assertPrint(TSIdentExpr.null, "null")
     }

--- a/Tests/TypeScriptASTTests/ScanDependencyTests.swift
+++ b/Tests/TypeScriptASTTests/ScanDependencyTests.swift
@@ -339,4 +339,22 @@ final class ScanDependencyTests: TestCaseBase {
 
         XCTAssertEqual(Set(s.scanDependency()), ["x", "y", "b"])
     }
+
+    func testTemplateLiteral() {
+        let s = TSSourceFile([
+            TSVarDecl(kind: .const, name: "a", initializer: TSNumberLiteralExpr(1)),
+            TSVarDecl(kind: .const, name: "c", initializer: TSTemplateLiteralExpr("\(ident: "a"), \(ident: "b")")),
+        ])
+
+        assertPrint(
+            s, """
+            const a = 1;
+
+            const c = `${a}, ${b}`;
+
+            """
+        )
+
+        XCTAssertEqual(Set(s.scanDependency()), ["b"])
+    }
 }


### PR DESCRIPTION
テンプレートリテラルを表現することができなかったので、`TSTemplateLiteralExpr`を追加します。
StringInterpolationによってSwiftの文字列リテラルと連携できるようにしました。
`\(ident: "foo")` か、 `\(someExpr)` の形式で埋め込むと 
```
`${foo}`
`${{ some: "obj"}}`
```
のような形式で展開されます。本質的は`\(ident:)` は不要ですが、利便性のために追加しています。

また細かいですが `readonly` modifierとknown symbolとして`super`が定義されていなかったので追加しました。