### PR TITLE
escape for invalid identifier name in object literal

### DIFF
--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -75,6 +75,12 @@ public final class ASTPrinter: ASTVisitor {
     }
 
     private func isValidIdentifier(_ name: String) -> Bool {
+        guard let start = name.unicodeScalars.first else {
+            return false
+        }
+        if CharacterSet(charactersIn: "0123456789").contains(start) {
+            return false
+        }
         let safeSet = CharacterSet.alphanumerics.union(.init(charactersIn: "_$"))
         return name.components(separatedBy: safeSet.inverted).count == 1
     }

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -75,14 +75,18 @@ public final class ASTPrinter: ASTVisitor {
     }
 
     private func isValidIdentifier(_ name: String) -> Bool {
-        guard let start = name.unicodeScalars.first else {
+        let scalars = name.unicodeScalars
+        guard let start = scalars.first,
+              (start.properties.isIDStart || start == "_" || start == "$") else {
             return false
         }
-        if CharacterSet(charactersIn: "0123456789").contains(start) {
-            return false
+        let i = scalars.index(after: scalars.startIndex)
+        return scalars[i...].allSatisfy { scaler in
+            scaler.properties.isIDContinue
+            || scaler == "$"
+            || scaler == "\u{200D}"
+            || scaler == "\u{200C}"
         }
-        let safeSet = CharacterSet.alphanumerics.union(.init(charactersIn: "_$"))
-        return name.components(separatedBy: safeSet.inverted).count == 1
     }
 
     private func nest<R>(

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -74,6 +74,11 @@ public final class ASTPrinter: ASTVisitor {
         return s
     }
 
+    private func isValidIdentifier(_ name: String) -> Bool {
+        let safeSet = CharacterSet.alphanumerics.union(.init(charactersIn: "_$"))
+        return name.components(separatedBy: safeSet.inverted).count == 1
+    }
+
     private func nest<R>(
         scope: ScopeKind? = nil,
         bracket: String? = nil,
@@ -493,7 +498,13 @@ public final class ASTPrinter: ASTVisitor {
     private func write(field: TSObjectExpr.Field) {
         switch field {
         case .named(let name, let value):
-            printer.write(name)
+            if isValidIdentifier(name) {
+                printer.write(name)
+            } else {
+                printer.write("\"")
+                printer.write(escape(name))
+                printer.write("\"")
+            }
             printer.write(": ")
             walk(value)
         case .shorthandPropertyNames(let name):

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -338,7 +338,14 @@ public final class ASTPrinter: ASTVisitor {
 
     public override func visit(method: TSMethodDecl) -> Bool {
         write(modifiers: method.modifiers)
-        printer.write(space: " ", method.name)
+        printer.write(space: " ")
+        if isValidIdentifier(method.name) {
+            printer.write(method.name)
+        } else {
+            printer.write("\"")
+            printer.write(escape(method.name))
+            printer.write("\"")
+        }
         write(genericParams: method.genericParams)
         write(params: method.params)
         if let result = method.result {

--- a/Tests/TypeScriptASTTests/PrintExprTests.swift
+++ b/Tests/TypeScriptASTTests/PrintExprTests.swift
@@ -251,7 +251,8 @@ final class PrintExprTests: TestCaseBase {
                 ), value: TSIdentExpr.true),
                 .method(.init(name: "c", params: [], body: TSBlockStmt([]))),
                 .named(name: "Content-Type", value: TSStringLiteralExpr("application/json")),
-                .method(.init(name: "Foo&Bar", params: [], body: TSBlockStmt([]))),
+                .method(.init(name: "0f", params: [], body: TSBlockStmt([]))),
+                .named(name: "", value: TSIdentExpr.true),
             ]),
             """
             {
@@ -260,7 +261,8 @@ final class PrintExprTests: TestCaseBase {
                 [a + 42]: true,
                 c() {},
                 "Content-Type": "application/json",
-                "Foo&Bar"() {}
+                "0f"() {},
+                "": true
             }
             """
         )

--- a/Tests/TypeScriptASTTests/PrintExprTests.swift
+++ b/Tests/TypeScriptASTTests/PrintExprTests.swift
@@ -251,6 +251,7 @@ final class PrintExprTests: TestCaseBase {
                 ), value: TSIdentExpr.true),
                 .method(.init(name: "c", params: [], body: TSBlockStmt([]))),
                 .named(name: "Content-Type", value: TSStringLiteralExpr("application/json")),
+                .method(.init(name: "Foo&Bar", params: [], body: TSBlockStmt([]))),
             ]),
             """
             {
@@ -258,7 +259,8 @@ final class PrintExprTests: TestCaseBase {
                 b,
                 [a + 42]: true,
                 c() {},
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
+                "Foo&Bar"() {}
             }
             """
         )

--- a/Tests/TypeScriptASTTests/PrintExprTests.swift
+++ b/Tests/TypeScriptASTTests/PrintExprTests.swift
@@ -249,14 +249,16 @@ final class PrintExprTests: TestCaseBase {
                 .computedPropertyNames(name: TSInfixOperatorExpr(
                     TSIdentExpr("a"), "+", TSNumberLiteralExpr(42)
                 ), value: TSIdentExpr.true),
-                .method(.init(name: "c", params: [], body: TSBlockStmt([])))
+                .method(.init(name: "c", params: [], body: TSBlockStmt([]))),
+                .named(name: "Content-Type", value: TSStringLiteralExpr("application/json")),
             ]),
             """
             {
                 a: true,
                 b,
                 [a + 42]: true,
-                c() {}
+                c() {},
+                "Content-Type": "application/json"
             }
             """
         )


### PR DESCRIPTION
以下のコードは、次のように出力されます。

```swift
TSObjectExpr([
  .named(name: "Content-Type", value: TSStringLiteralExpr("application/json")),
])
```
結果:
```ts
{
  Content-Type: "application/json"
}
```

これはTSとして不正であり、プロパティ名を`""`でエスケープする必要があります。
このエスケープの動作を実装します。