### PR TITLE
Allow member access to optional value

### DIFF
--- a/Sources/ASTNodeModule/Expr/TSMemberExpr.swift
+++ b/Sources/ASTNodeModule/Expr/TSMemberExpr.swift
@@ -1,8 +1,10 @@
 public final class TSMemberExpr: _TSExpr {
     public init(
         base: any TSExpr,
+        isOptional: Bool = false,
         name: TSIdentExpr
     ) {
+        self.isOptional = isOptional
         self.name = name
         self.base = base
     }
@@ -13,5 +15,6 @@ public final class TSMemberExpr: _TSExpr {
     }
 
     @AnyTSExprStorage public var base: any TSExpr
+    public var isOptional: Bool
     @ASTNodeStorage public var name: TSIdentExpr
 }

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -464,6 +464,9 @@ public final class ASTPrinter: ASTVisitor {
 
     public override func visit(member: TSMemberExpr) -> Bool {
         walk(member.base)
+        if member.isOptional {
+            printer.write("?")
+        }
         printer.write(".")
         walk(member.name)
         return false

--- a/Tests/TypeScriptASTTests/PrintExprTests.swift
+++ b/Tests/TypeScriptASTTests/PrintExprTests.swift
@@ -336,6 +336,15 @@ final class PrintExprTests: TestCaseBase {
             ),
             "A.B.C"
         )
+
+        assertPrint(
+            TSMemberExpr(
+                base: TSIdentExpr("A"),
+                isOptional: true,
+                name: TSIdentExpr("B")
+            ),
+            "A?.B"
+        )
     }
 
     func testAssign() throws {


### PR DESCRIPTION
現状、以下のようなオプショナルな変数に対して`?.`でメンバアクセスする式を表現できないことに気づきました

```ts
const f: number | null = null;
f?.toString() // ここの f? の部分
```

これに対応するために、TSMemberExprにパラメータを追加します