### PR TITLE
Refine object expr

### DIFF
--- a/Sources/ASTNodeModule/Expr/TSBooleanLiteralExpr.swift
+++ b/Sources/ASTNodeModule/Expr/TSBooleanLiteralExpr.swift
@@ -1,0 +1,15 @@
+public final class TSBooleanLiteralExpr: _TSExpr {
+    public init(_ value: Bool) {
+        self.value = value
+    }
+
+    public private(set) unowned var parent: (any ASTNode)?
+    internal func _setParent(_ newValue: (any ASTNode)?) {
+        parent = newValue
+    }
+
+    public var value: Bool
+
+    public static var `true`: TSBooleanLiteralExpr { Self(true) }
+    public static var `false`: TSBooleanLiteralExpr { Self(false) }
+}

--- a/Sources/ASTNodeModule/Expr/TSIdentExpr.swift
+++ b/Sources/ASTNodeModule/Expr/TSIdentExpr.swift
@@ -10,11 +10,8 @@ public final class TSIdentExpr: _TSExpr {
 
     public var name: String
 
-    public static var null: TSIdentExpr { TSIdentExpr("null") }
     public static var undefined: TSIdentExpr { TSIdentExpr("undefined") }
     public static var void: TSIdentExpr { TSIdentExpr("void") }
     public static var never: TSIdentExpr { TSIdentExpr("never") }
-    public static var `true`: TSIdentExpr { TSIdentExpr("true") }
-    public static var `false`: TSIdentExpr { TSIdentExpr("false") }
     public static var this: TSIdentExpr { TSIdentExpr("this") }
 }

--- a/Sources/ASTNodeModule/Expr/TSNullLiteralExpr.swift
+++ b/Sources/ASTNodeModule/Expr/TSNullLiteralExpr.swift
@@ -1,0 +1,9 @@
+public final class TSNullLiteralExpr: _TSExpr {
+    public init() {
+    }
+
+    public private(set) unowned var parent: (any ASTNode)?
+    internal func _setParent(_ newValue: (any ASTNode)?) {
+        parent = newValue
+    }
+}

--- a/Sources/ASTNodeModule/Expr/TSObjectExpr.swift
+++ b/Sources/ASTNodeModule/Expr/TSObjectExpr.swift
@@ -1,9 +1,10 @@
 public final class TSObjectExpr: _TSExpr {
     public enum Field {
         case named(name: String, value: any TSExpr)
-        case shorthandPropertyNames(name: String)
+        case shorthandPropertyNames(value: TSIdentExpr)
         case computedPropertyNames(name: any TSExpr, value: any TSExpr)
         case method(TSMethodDecl)
+        case destructuring(value: any TSExpr)
     }
 
     public init(
@@ -24,13 +25,15 @@ public final class TSObjectExpr: _TSExpr {
                 switch field {
                 case .named(_, let value):
                     value.setParent(nil)
-                case .shorthandPropertyNames:
-                    break
+                case .shorthandPropertyNames(let value):
+                    value.setParent(nil)
                 case .computedPropertyNames(let name, let value):
                     name.setParent(nil)
                     value.setParent(nil)
                 case .method(let decl):
                     decl.setParent(nil)
+                case .destructuring(let value):
+                    value.setParent(nil)
                 }
             }
             _fields = newValue
@@ -38,13 +41,15 @@ public final class TSObjectExpr: _TSExpr {
                 switch field {
                 case .named(_, let value):
                     value.setParent(self)
-                case .shorthandPropertyNames:
-                    break
+                case .shorthandPropertyNames(let value):
+                    value.setParent(self)
                 case .computedPropertyNames(let name, let value):
                     name.setParent(self)
                     value.setParent(self)
                 case .method(let decl):
                     decl.setParent(self)
+                case .destructuring(let value):
+                    value.setParent(self)
                 }
             }
         }

--- a/Sources/TypeScriptAST/Component/ASTVisitor.swift
+++ b/Sources/TypeScriptAST/Component/ASTVisitor.swift
@@ -33,8 +33,8 @@ open class ASTVisitor {
         switch field {
         case .named(_, let value):
             walk(value)
-        case .shorthandPropertyNames:
-            break
+        case .shorthandPropertyNames(let value):
+            walk(value)
         case .computedPropertyNames(let name, let value):
             walk(name)
             walk(value)
@@ -102,6 +102,10 @@ open class ASTVisitor {
     open func visitPost(new: TSNewExpr) {}
     open func visit(member: TSMemberExpr) -> Bool { defaultVisitResult }
     open func visitPost(member: TSMemberExpr) {}
+    open func visit(nullLiteral: TSNullLiteralExpr) -> Bool { defaultVisitResult }
+    open func visitPost(nullLiteral: TSNullLiteralExpr) {}
+    open func visit(booleanLiteral: TSBooleanLiteralExpr) -> Bool { defaultVisitResult }
+    open func visitPost(booleanLiteral: TSBooleanLiteralExpr) {}
     open func visit(numberLiteral: TSNumberLiteralExpr) -> Bool { defaultVisitResult }
     open func visitPost(numberLiteral: TSNumberLiteralExpr) {}
     open func visit(object: TSObjectExpr) -> Bool { defaultVisitResult }
@@ -186,6 +190,8 @@ open class ASTVisitor {
         case let x as TSInfixOperatorExpr: visitImpl(infixOperator: x)
         case let x as TSNewExpr: visitImpl(new: x)
         case let x as TSMemberExpr: visitImpl(member: x)
+        case let x as TSNullLiteralExpr: visitImpl(nullLiteral: x)
+        case let x as TSBooleanLiteralExpr: visitImpl(booleanLiteral: x)
         case let x as TSNumberLiteralExpr: visitImpl(numberLiteral: x)
         case let x as TSObjectExpr: visitImpl(object: x)
         case let x as TSParenExpr: visitImpl(paren: x)
@@ -356,6 +362,16 @@ open class ASTVisitor {
         walk(member.base)
         walk(member.name)
         visitPost(member: member)
+    }
+
+    private func visitImpl(nullLiteral: TSNullLiteralExpr) {
+        guard visit(nullLiteral: nullLiteral) else { return }
+        visitPost(nullLiteral: nullLiteral)
+    }
+
+    private func visitImpl(booleanLiteral: TSBooleanLiteralExpr) {
+        guard visit(booleanLiteral: booleanLiteral) else { return }
+        visitPost(booleanLiteral: booleanLiteral)
     }
 
     private func visitImpl(numberLiteral: TSNumberLiteralExpr) {

--- a/Sources/TypeScriptAST/Component/ASTVisitor.swift
+++ b/Sources/TypeScriptAST/Component/ASTVisitor.swift
@@ -40,6 +40,8 @@ open class ASTVisitor {
             walk(value)
         case .method(let decl):
             walk(decl)
+        case .destructuring(let value):
+            walk(value)
         }
     }
 

--- a/Sources/TypeScriptAST/Component/SymbolTable.swift
+++ b/Sources/TypeScriptAST/Component/SymbolTable.swift
@@ -13,15 +13,12 @@ public struct SymbolTable {
     }
 
     public static let standardLibrarySymbols: Set<String> = [
-        "null",
         "undefined",
         "void",
         "never",
         "any",
         "unknown",
         "boolean",
-        "true",
-        "false",
         "number",
         "string",
         "this",

--- a/Sources/TypeScriptAST/Dependency/ScanDependency.swift
+++ b/Sources/TypeScriptAST/Dependency/ScanDependency.swift
@@ -8,7 +8,7 @@ extension TSSourceFile {
 
 private final class Impl: ASTVisitor {
     struct Context {
-        var knownNames: Set<String> = []
+        var knownNames: Set<String> = wellKnownGlobalObjects
     }
 
     var contextStack: [Context]
@@ -18,6 +18,10 @@ private final class Impl: ASTVisitor {
             contextStack[contextStack.count - 1] = newValue
         }
     }
+
+    static let wellKnownGlobalObjects: Set<String> = [
+        TSIdentExpr.undefined.name,
+    ]
 
     override init() {
         contextStack = [Context()]

--- a/Sources/TypeScriptAST/Dependency/ScanDependency.swift
+++ b/Sources/TypeScriptAST/Dependency/ScanDependency.swift
@@ -8,7 +8,7 @@ extension TSSourceFile {
 
 private final class Impl: ASTVisitor {
     struct Context {
-        var knownNames: Set<String> = wellKnownGlobalObjects
+        var knownNames: Set<String> = []
     }
 
     var contextStack: [Context]
@@ -24,7 +24,9 @@ private final class Impl: ASTVisitor {
     ]
 
     override init() {
-        contextStack = [Context()]
+        var rootContext = Context()
+        rootContext.knownNames = Self.wellKnownGlobalObjects
+        contextStack = [rootContext]
         super.init()
     }
 

--- a/Sources/TypeScriptAST/Dependency/ScanDependency.swift
+++ b/Sources/TypeScriptAST/Dependency/ScanDependency.swift
@@ -19,14 +19,8 @@ private final class Impl: ASTVisitor {
         }
     }
 
-    static let wellKnownGlobalObjects: Set<String> = [
-        TSIdentExpr.undefined.name,
-    ]
-
     override init() {
-        var rootContext = Context()
-        rootContext.knownNames = Self.wellKnownGlobalObjects
-        contextStack = [rootContext]
+        contextStack = [Context()]
         super.init()
     }
 

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -501,6 +501,20 @@ public final class ASTPrinter: ASTVisitor {
         return false
     }
 
+    public override func visit(nullLiteral: TSNullLiteralExpr) -> Bool {
+        printer.write("null")
+        return false
+    }
+
+    public override func visit(booleanLiteral: TSBooleanLiteralExpr) -> Bool {
+        if booleanLiteral.value {
+            printer.write("true")
+        } else {
+            printer.write("false")
+        }
+        return false
+    }
+
     public override func visit(numberLiteral: TSNumberLiteralExpr) -> Bool {
         printer.write(numberLiteral.text)
         return false

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -541,8 +541,8 @@ public final class ASTPrinter: ASTVisitor {
             }
             printer.write(": ")
             walk(value)
-        case .shorthandPropertyNames(let name):
-            printer.write(name)
+        case .shorthandPropertyNames(let value):
+            walk(value)
         case .computedPropertyNames(let name, let value):
             printer.write("[")
             walk(name)
@@ -551,6 +551,9 @@ public final class ASTPrinter: ASTVisitor {
             walk(value)
         case .method(let decl):
             walk(decl)
+        case .destructuring(let value):
+            printer.write("...")
+            walk(value)
         }
     }
 

--- a/Tests/TypeScriptASTTests/PrintExprTests.swift
+++ b/Tests/TypeScriptASTTests/PrintExprTests.swift
@@ -275,6 +275,7 @@ final class PrintExprTests: TestCaseBase {
                     TSIdentExpr("a"), "+", TSNumberLiteralExpr(42)
                 ), value: TSBooleanLiteralExpr.true),
                 .method(.init(name: "c", params: [], body: TSBlockStmt([]))),
+                .destructuring(value: TSIdentExpr("d")),
                 .named(name: "Content-Type", value: TSStringLiteralExpr("application/json")),
                 .method(.init(name: "0f", params: [], body: TSBlockStmt([]))),
                 .named(name: "", value: TSBooleanLiteralExpr.true),
@@ -285,6 +286,7 @@ final class PrintExprTests: TestCaseBase {
                 b,
                 [a + 42]: true,
                 c() {},
+                ...d,
                 "Content-Type": "application/json",
                 "0f"() {},
                 "": true

--- a/Tests/TypeScriptASTTests/PrintExprTests.swift
+++ b/Tests/TypeScriptASTTests/PrintExprTests.swift
@@ -183,7 +183,16 @@ final class PrintExprTests: TestCaseBase {
     }
 
     func testIdent() throws {
-        assertPrint(TSIdentExpr.null, "null")
+        assertPrint(TSIdentExpr.undefined, "undefined")
+    }
+
+    func testNull() throws {
+        assertPrint(TSNullLiteralExpr(), "null")
+    }
+
+    func testBoolean() throws {
+        assertPrint(TSBooleanLiteralExpr.true, "true")
+        assertPrint(TSBooleanLiteralExpr.false, "false")
     }
 
     func testAs() throws {
@@ -260,15 +269,15 @@ final class PrintExprTests: TestCaseBase {
 
         assertPrint(
             TSObjectExpr([
-                .named(name: "a", value: TSIdentExpr.true),
-                .shorthandPropertyNames(name: "b"),
+                .named(name: "a", value: TSBooleanLiteralExpr.true),
+                .shorthandPropertyNames(value: TSIdentExpr("b")),
                 .computedPropertyNames(name: TSInfixOperatorExpr(
                     TSIdentExpr("a"), "+", TSNumberLiteralExpr(42)
-                ), value: TSIdentExpr.true),
+                ), value: TSBooleanLiteralExpr.true),
                 .method(.init(name: "c", params: [], body: TSBlockStmt([]))),
                 .named(name: "Content-Type", value: TSStringLiteralExpr("application/json")),
                 .method(.init(name: "0f", params: [], body: TSBlockStmt([]))),
-                .named(name: "", value: TSIdentExpr.true),
+                .named(name: "", value: TSBooleanLiteralExpr.true),
             ]),
             """
             {
@@ -286,7 +295,7 @@ final class PrintExprTests: TestCaseBase {
 
     func testClosure() throws {
         assertPrint(
-            TSClosureExpr(params: [], body: TSIdentExpr.true),
+            TSClosureExpr(params: [], body: TSBooleanLiteralExpr.true),
             "() => true"
         )
 
@@ -305,7 +314,7 @@ final class PrintExprTests: TestCaseBase {
                 ],
                 result: TSIdentType.boolean,
                 body: TSBlockStmt([
-                    TSReturnStmt(TSIdentExpr.true)
+                    TSReturnStmt(TSBooleanLiteralExpr.true)
                 ])
             ),
             """
@@ -449,10 +458,10 @@ final class PrintExprTests: TestCaseBase {
                 expr: TSIdentExpr("x"),
                 cases: [
                     TSCaseStmt(expr: TSNumberLiteralExpr(1), elements: [
-                        TSReturnStmt(TSIdentExpr.true)
+                        TSReturnStmt(TSBooleanLiteralExpr.true)
                     ]),
                     TSDefaultStmt(elements: [
-                        TSReturnStmt(TSIdentExpr.false)
+                        TSReturnStmt(TSBooleanLiteralExpr.false)
                     ])
                 ]
             ),

--- a/Tests/TypeScriptASTTests/ScanDependencyTests.swift
+++ b/Tests/TypeScriptASTTests/ScanDependencyTests.swift
@@ -384,6 +384,6 @@ final class ScanDependencyTests: TestCaseBase {
             """
         )
 
-        XCTAssertEqual(Set(s.scanDependency()), ["b", "c", "e"])
+        XCTAssertEqual(Set(s.scanDependency()), ["b", "c", "e", "undefined"])
     }
 }

--- a/Tests/TypeScriptASTTests/ScanDependencyTests.swift
+++ b/Tests/TypeScriptASTTests/ScanDependencyTests.swift
@@ -357,4 +357,33 @@ final class ScanDependencyTests: TestCaseBase {
 
         XCTAssertEqual(Set(s.scanDependency()), ["b"])
     }
+
+    func testObjectExpr() {
+        let s = TSSourceFile([
+            TSVarDecl(kind: .const, name: "v", initializer: TSObjectExpr([
+                .named(name: "a", value: TSBooleanLiteralExpr.true),
+                .shorthandPropertyNames(value: TSIdentExpr("b")),
+                .computedPropertyNames(name: TSInfixOperatorExpr(
+                    TSIdentExpr("c"), "+", TSNumberLiteralExpr(42)
+                ), value: TSIdentExpr.undefined),
+                .method(.init(name: "d", params: [], body: TSBlockStmt([]))),
+                .destructuring(value: TSIdentExpr("e")),
+            ])),
+        ])
+
+        assertPrint(
+            s, """
+            const v = {
+                a: true,
+                b,
+                [c + 42]: undefined,
+                d() {},
+                ...e
+            };
+
+            """
+        )
+
+        XCTAssertEqual(Set(s.scanDependency()), ["b", "c", "e"])
+    }
 }


### PR DESCRIPTION
いくつかの問題点を修正します

## オブジェクトリテラルにおける分割代入のサポート

```ts
const a = { ...b };
``` 

スプレッド演算子のことを忘れていました。単にサポートを追加します

## いくつかのDependency判定が間違っているのを修正1

```ts
const a = { b }; // このbが使われた依存として検出されない
```

ObjectLiteralExprのshorthandPropertyNamesにおいて、ここで使われたIdentifierが使用された依存として登録されない問題を修正します。
単にStringで扱われていたIdentifierをTSIdentExprとして扱います。

## いくつかのDependency判定が間違っているのを修正2

`true` `false` `null` `undefined`
が依存として登録されてしまう問題を修正します。
Booleanとnullについては、これまでTSIdentExprとされていましたが、これは正しくなく本来はBooleanLiteralやNullLiteralであるため、そのように扱います。
undfinedについては、これはグローバルな値であるため依存検出器から除外できるよう設定します
