### PR TITLE
Resume removed literal symbols

### DIFF
--- a/Sources/TypeScriptAST/Component/SymbolTable.swift
+++ b/Sources/TypeScriptAST/Component/SymbolTable.swift
@@ -13,12 +13,15 @@ public struct SymbolTable {
     }
 
     public static let standardLibrarySymbols: Set<String> = [
+        "null",
         "undefined",
         "void",
         "never",
         "any",
         "unknown",
         "boolean",
+        "true",
+        "false",
         "number",
         "string",
         "this",


### PR DESCRIPTION
https://github.com/omochi/TypeScriptAST/pull/11#issuecomment-1354263337 に関する修正です。
#11 で `TSBooleanLiteralExpr`、`TSNullLiteralExpr`が追加されたことによって`null`,`true`,`false`の**値**は個別に型付けされ、ASTVisitorで個別に扱われるようになりました。
これでVisitor側でASTNodeを区別できるようになったので`SymbolTable`の定義からこれらは不要だと思い、リストから削除しました。


値として利用されているときはこれで良かったですが、型としてこれらが使われるケースを見逃していました。
型として`null`や`true`が使用された場合はscanDependencyにおいてこれらが検出されるため、無視するためにSymbolTableの定義にこれらは残しておくべきだと思いました。