### PR TITLE
Add genericParams to TSFunctionType and TSClosureExpr

### DIFF
--- a/Sources/ASTNodeModule/Expr/TSClosureExpr.swift
+++ b/Sources/ASTNodeModule/Expr/TSClosureExpr.swift
@@ -1,10 +1,12 @@
 public final class TSClosureExpr: _TSExpr {
     public init(
+        genericParams: [String] = [],
         hasParen: Bool = true,
         params: [TSFunctionType.Param],
         result: (any TSType)? = nil,
         body: any TSStmt
     ) {
+        self.genericParams = genericParams
         self.hasParen = hasParen
         self.params = params
         self.result = result
@@ -16,6 +18,7 @@ public final class TSClosureExpr: _TSExpr {
         parent = newValue
     }
 
+    public var genericParams: [String]
     public var hasParen: Bool
     public var params: [TSFunctionType.Param] {
         get { _params }

--- a/Sources/ASTNodeModule/Type/TSFunctionType.swift
+++ b/Sources/ASTNodeModule/Type/TSFunctionType.swift
@@ -16,9 +16,11 @@ public final class TSFunctionType: _TSType {
     }
 
     public init(
+        genericParams: [String] = [],
         params: [Param],
         result: any TSType
     ) {
+        self.genericParams = genericParams
         self.params = params
         self.result = result
     }
@@ -28,6 +30,7 @@ public final class TSFunctionType: _TSType {
         parent = newValue
     }
 
+    public var genericParams: [String]
     public var params: [Param] {
         get { _params }
         set {

--- a/Sources/TypeScriptAST/Dependency/ScanDependency.swift
+++ b/Sources/TypeScriptAST/Dependency/ScanDependency.swift
@@ -160,6 +160,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(closure: TSClosureExpr) -> Bool {
         push()
+        addNames(closure.genericParams)
         addNames(closure.params.map { $0.name })
         return true
     }

--- a/Sources/TypeScriptAST/Dependency/ScanDependency.swift
+++ b/Sources/TypeScriptAST/Dependency/ScanDependency.swift
@@ -201,4 +201,14 @@ private final class Impl: ASTVisitor {
         }
         return true
     }
+
+    override func visit(function: TSFunctionType) -> Bool {
+        push()
+        addNames(function.genericParams)
+        return true
+    }
+
+    override func visitPost(function: TSFunctionType) {
+        pop()
+    }
 }

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -762,6 +762,7 @@ public final class ASTPrinter: ASTVisitor {
     }
 
     public override func visit(function: TSFunctionType) -> Bool {
+        write(genericParams: function.genericParams)
         write(params: function.params)
         printer.write(" => ")
         walk(function.result)

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -449,6 +449,15 @@ public final class ASTPrinter: ASTVisitor {
     }
 
     public override func visit(closure: TSClosureExpr) -> Bool {
+        switch closure.genericParams.count {
+        case 1:
+            nest(bracket: "<") {
+                printer.write(closure.genericParams[0])
+                printer.write(",")
+            }
+        default:
+            write(genericParams: closure.genericParams)
+        }
         write(params: closure.params, paren: closure.hasParen)
         if let result = closure.result {
             printer.write(": ")

--- a/Tests/TypeScriptASTTests/PrintExprTests.swift
+++ b/Tests/TypeScriptASTTests/PrintExprTests.swift
@@ -330,6 +330,18 @@ final class PrintExprTests: TestCaseBase {
             }
             """
         )
+
+        assertPrint(
+            TSClosureExpr(genericParams: ["T"], params: [.init(name: "t", type: TSIdentType("T"))], body: TSIdentExpr("t")),
+            "<T,>(t: T) => t"
+        )
+        assertPrint(
+            TSClosureExpr(genericParams: ["T", "U"], params: [.init(name: "tu", type: TSIntersectionType([
+                TSIdentType("T"),
+                TSIdentType("U"),
+            ]))], body: TSIdentExpr("tu")),
+            "<T, U>(tu: T & U) => tu"
+        )
     }
 
     func testCustom() throws {

--- a/Tests/TypeScriptASTTests/PrintTypeTests.swift
+++ b/Tests/TypeScriptASTTests/PrintTypeTests.swift
@@ -219,6 +219,8 @@ final class PrintTypeTests: TestCaseBase {
             ) => void
             """
         )
+
+        assertPrint(TSFunctionType(genericParams: ["T"], params: [], result: TSIdentType("T")), "<T>() => T")
     }
 
     func testCustom() throws {

--- a/Tests/TypeScriptASTTests/ScanDependencyTests.swift
+++ b/Tests/TypeScriptASTTests/ScanDependencyTests.swift
@@ -386,4 +386,27 @@ final class ScanDependencyTests: TestCaseBase {
 
         XCTAssertEqual(Set(s.scanDependency()), ["b", "c", "e", "undefined"])
     }
+
+    func testFunctionType() {
+        let s = TSSourceFile([
+            TSTypeDecl(name: "t", type: TSObjectType([
+                .init(name: "f", type: TSFunctionType(
+                    genericParams: ["T"],
+                    params: [.init(name: "a", type: TSIdentType("A"))],
+                    result: TSIdentType("T")
+                ))
+            ])),
+        ])
+
+        assertPrint(
+            s, """
+            type t = {
+                f: <T>(a: A) => T;
+            };
+
+            """
+        )
+
+        XCTAssertEqual(Set(s.scanDependency()), ["A"])
+    }
 }

--- a/Tests/TypeScriptASTTests/ScanDependencyTests.swift
+++ b/Tests/TypeScriptASTTests/ScanDependencyTests.swift
@@ -409,4 +409,30 @@ final class ScanDependencyTests: TestCaseBase {
 
         XCTAssertEqual(Set(s.scanDependency()), ["A"])
     }
+
+    func testClosureExpr() {
+        let s = TSSourceFile([
+            TSVarDecl(
+                kind: .const,
+                name: "f",
+                initializer: TSClosureExpr(
+                    genericParams: ["T"],
+                    params: [.init(name: "tu", type: TSIntersectionType([
+                        TSIdentType("T"),
+                        TSIdentType("U"),
+                    ]))],
+                    body: TSIdentExpr("tu")
+                )
+            )
+        ])
+
+        assertPrint(
+            s, """
+            const f = <T,>(tu: T & U) => tu;
+
+            """
+        )
+
+        XCTAssertEqual(Set(s.scanDependency()), ["U"])
+    }
 }


### PR DESCRIPTION
TSFunctionType と TSClosureExprが型パラメータをとれるようにします。

TSClosureExprのみ、型引数が1個のとき用の特別処理が入っています。
```ts
<T,>(t: T) => t
```

`,`がないとシンタックスエラーになるので、こうしています