### PR TITLE
Add Complex types

### DIFF
--- a/Sources/ASTNodeModule/Type/TSConditionalType.swift
+++ b/Sources/ASTNodeModule/Type/TSConditionalType.swift
@@ -1,0 +1,23 @@
+public final class TSConditionalType: _TSType {
+    public init(
+        _ check: any TSType,
+        extends: any TSType,
+        `true`: any TSType,
+        `false`: any TSType
+    ) {
+        self.check = check
+        self.extends = extends
+        self.true = `true`
+        self.false = `false`
+    }
+
+    public private(set) unowned var parent: (any ASTNode)?
+    internal func _setParent(_ newValue: (any ASTNode)?) {
+        parent = newValue
+    }
+
+    @AnyTSTypeStorage public var check: any TSType
+    @AnyTSTypeStorage public var extends: any TSType
+    @AnyTSTypeStorage public var `true`: any TSType
+    @AnyTSTypeStorage public var `false`: any TSType
+}

--- a/Sources/ASTNodeModule/Type/TSIndexedAccessType.swift
+++ b/Sources/ASTNodeModule/Type/TSIndexedAccessType.swift
@@ -1,0 +1,23 @@
+public final class TSIndexedAccessType: _TSType {
+    internal init(parent: (ASTNode)?, base: TSType, index: TSType) {
+        self.parent = parent
+        self.base = base
+        self.index = index
+    }
+    
+    public init(
+        _ base: any TSType,
+        index: any TSType
+    ) {
+        self.base = base
+        self.index = index
+    }
+
+    public private(set) unowned var parent: (any ASTNode)?
+    internal func _setParent(_ newValue: (any ASTNode)?) {
+        parent = newValue
+    }
+
+    @AnyTSTypeStorage public var base: any TSType
+    @AnyTSTypeStorage public var index: any TSType
+}

--- a/Sources/ASTNodeModule/Type/TSIndexedAccessType.swift
+++ b/Sources/ASTNodeModule/Type/TSIndexedAccessType.swift
@@ -1,10 +1,4 @@
 public final class TSIndexedAccessType: _TSType {
-    internal init(parent: (ASTNode)?, base: TSType, index: TSType) {
-        self.parent = parent
-        self.base = base
-        self.index = index
-    }
-    
     public init(
         _ base: any TSType,
         index: any TSType

--- a/Sources/ASTNodeModule/Type/TSInferType.swift
+++ b/Sources/ASTNodeModule/Type/TSInferType.swift
@@ -1,0 +1,12 @@
+public final class TSInferType: _TSType {
+    public init(name: String) {
+        self.name = name
+    }
+
+    public private(set) unowned var parent: (any ASTNode)?
+    internal func _setParent(_ newValue: (any ASTNode)?) {
+        parent = newValue
+    }
+
+    public var name: String
+}

--- a/Sources/ASTNodeModule/Type/TSNumberLiteralType.swift
+++ b/Sources/ASTNodeModule/Type/TSNumberLiteralType.swift
@@ -1,0 +1,16 @@
+public final class TSNumberLiteralType: _TSType {
+    public init(_ text: String) {
+        self.text = text
+    }
+
+    public convenience init(_ int: Int) {
+        self.init("\(int)")
+    }
+
+    public private(set) unowned var parent: (any ASTNode)?
+    internal func _setParent(_ newValue: (any ASTNode)?) {
+        parent = newValue
+    }
+
+    public var text: String
+}

--- a/Sources/ASTNodeModule/Type/TSType.swift
+++ b/Sources/ASTNodeModule/Type/TSType.swift
@@ -14,6 +14,7 @@ extension TSType {
     public var asIdent: TSIdentType? { self as? TSIdentType }
     public var asIntersection: TSIntersectionType? { self as? TSIntersectionType }
     public var asMember: TSMemberType? { self as? TSMemberType }
+    public var asNumberLiteral: TSNumberLiteralType? { self as? TSNumberLiteralType }
     public var asObject: TSObjectType? { self as? TSObjectType }
     public var asStringLiteral: TSStringLiteralType? { self as? TSStringLiteralType }
     public var asUnion: TSUnionType? { self as? TSUnionType }

--- a/Sources/ASTNodeModule/Type/TSType.swift
+++ b/Sources/ASTNodeModule/Type/TSType.swift
@@ -7,6 +7,7 @@ internal protocol _TSType: _ASTNode & TSType {}
 extension TSType {
     // @codegen(as)
     public var asArray: TSArrayType? { self as? TSArrayType }
+    public var asConditional: TSConditionalType? { self as? TSConditionalType }
     public var asCustom: TSCustomType? { self as? TSCustomType }
     public var asDictionary: TSDictionaryType? { self as? TSDictionaryType }
     public var asFunction: TSFunctionType? { self as? TSFunctionType }

--- a/Sources/ASTNodeModule/Type/TSType.swift
+++ b/Sources/ASTNodeModule/Type/TSType.swift
@@ -12,6 +12,7 @@ extension TSType {
     public var asDictionary: TSDictionaryType? { self as? TSDictionaryType }
     public var asFunction: TSFunctionType? { self as? TSFunctionType }
     public var asIdent: TSIdentType? { self as? TSIdentType }
+    public var asInfer: TSInferType? { self as? TSInferType }
     public var asIntersection: TSIntersectionType? { self as? TSIntersectionType }
     public var asMember: TSMemberType? { self as? TSMemberType }
     public var asNumberLiteral: TSNumberLiteralType? { self as? TSNumberLiteralType }

--- a/Sources/ASTNodeModule/Type/TSType.swift
+++ b/Sources/ASTNodeModule/Type/TSType.swift
@@ -12,6 +12,7 @@ extension TSType {
     public var asDictionary: TSDictionaryType? { self as? TSDictionaryType }
     public var asFunction: TSFunctionType? { self as? TSFunctionType }
     public var asIdent: TSIdentType? { self as? TSIdentType }
+    public var asIndexedAccess: TSIndexedAccessType? { self as? TSIndexedAccessType }
     public var asInfer: TSInferType? { self as? TSInferType }
     public var asIntersection: TSIntersectionType? { self as? TSIntersectionType }
     public var asMember: TSMemberType? { self as? TSMemberType }

--- a/Sources/TypeScriptAST/Component/ASTVisitor.swift
+++ b/Sources/TypeScriptAST/Component/ASTVisitor.swift
@@ -162,6 +162,8 @@ open class ASTVisitor {
     open func visitPost(intersection: TSIntersectionType) {}
     open func visit(member: TSMemberType) -> Bool { defaultVisitResult }
     open func visitPost(member: TSMemberType) {}
+    open func visit(numberLiteral: TSNumberLiteralType) -> Bool { defaultVisitResult }
+    open func visitPost(numberLiteral: TSNumberLiteralType) {}
     open func visit(object: TSObjectType) -> Bool { defaultVisitResult }
     open func visitPost(object: TSObjectType) {}
     open func visit(stringLiteral: TSStringLiteralType) -> Bool { defaultVisitResult }
@@ -223,6 +225,7 @@ open class ASTVisitor {
         case let x as TSIdentType: visitImpl(ident: x)
         case let x as TSIntersectionType: visitImpl(intersection: x)
         case let x as TSMemberType: visitImpl(member: x)
+        case let x as TSNumberLiteralType: visitImpl(numberLiteral: x)
         case let x as TSObjectType: visitImpl(object: x)
         case let x as TSStringLiteralType: visitImpl(stringLiteral: x)
         case let x as TSUnionType: visitImpl(union: x)
@@ -546,6 +549,11 @@ open class ASTVisitor {
         walk(member.base)
         walk(member.genericArgs)
         visitPost(member: member)
+    }
+
+    private func visitImpl(numberLiteral: TSNumberLiteralType) {
+        guard visit(numberLiteral: numberLiteral) else { return }
+        visitPost(numberLiteral: numberLiteral)
     }
 
     private func visitImpl(object: TSObjectType) {

--- a/Sources/TypeScriptAST/Component/ASTVisitor.swift
+++ b/Sources/TypeScriptAST/Component/ASTVisitor.swift
@@ -158,6 +158,8 @@ open class ASTVisitor {
     open func visitPost(function: TSFunctionType) {}
     open func visit(ident: TSIdentType) -> Bool { defaultVisitResult }
     open func visitPost(ident: TSIdentType) {}
+    open func visit(infer: TSInferType) -> Bool { defaultVisitResult }
+    open func visitPost(infer: TSInferType) {}
     open func visit(intersection: TSIntersectionType) -> Bool { defaultVisitResult }
     open func visitPost(intersection: TSIntersectionType) {}
     open func visit(member: TSMemberType) -> Bool { defaultVisitResult }
@@ -223,6 +225,7 @@ open class ASTVisitor {
         case let x as TSDictionaryType: visitImpl(dictionary: x)
         case let x as TSFunctionType: visitImpl(function: x)
         case let x as TSIdentType: visitImpl(ident: x)
+        case let x as TSInferType: visitImpl(infer: x)
         case let x as TSIntersectionType: visitImpl(intersection: x)
         case let x as TSMemberType: visitImpl(member: x)
         case let x as TSNumberLiteralType: visitImpl(numberLiteral: x)
@@ -536,6 +539,11 @@ open class ASTVisitor {
         guard visit(ident: ident) else { return }
         walk(ident.genericArgs)
         visitPost(ident: ident)
+    }
+
+    private func visitImpl(infer: TSInferType) {
+        guard visit(infer: infer) else { return }
+        visitPost(infer: infer)
     }
 
     private func visitImpl(intersection: TSIntersectionType) {

--- a/Sources/TypeScriptAST/Component/ASTVisitor.swift
+++ b/Sources/TypeScriptAST/Component/ASTVisitor.swift
@@ -158,6 +158,8 @@ open class ASTVisitor {
     open func visitPost(function: TSFunctionType) {}
     open func visit(ident: TSIdentType) -> Bool { defaultVisitResult }
     open func visitPost(ident: TSIdentType) {}
+    open func visit(indexedAccess: TSIndexedAccessType) -> Bool { defaultVisitResult }
+    open func visitPost(indexedAccess: TSIndexedAccessType) {}
     open func visit(infer: TSInferType) -> Bool { defaultVisitResult }
     open func visitPost(infer: TSInferType) {}
     open func visit(intersection: TSIntersectionType) -> Bool { defaultVisitResult }
@@ -225,6 +227,7 @@ open class ASTVisitor {
         case let x as TSDictionaryType: visitImpl(dictionary: x)
         case let x as TSFunctionType: visitImpl(function: x)
         case let x as TSIdentType: visitImpl(ident: x)
+        case let x as TSIndexedAccessType: visitImpl(indexedAccess: x)
         case let x as TSInferType: visitImpl(infer: x)
         case let x as TSIntersectionType: visitImpl(intersection: x)
         case let x as TSMemberType: visitImpl(member: x)
@@ -539,6 +542,13 @@ open class ASTVisitor {
         guard visit(ident: ident) else { return }
         walk(ident.genericArgs)
         visitPost(ident: ident)
+    }
+
+    private func visitImpl(indexedAccess: TSIndexedAccessType) {
+        guard visit(indexedAccess: indexedAccess) else { return }
+        walk(indexedAccess.base)
+        walk(indexedAccess.index)
+        visitPost(indexedAccess: indexedAccess)
     }
 
     private func visitImpl(infer: TSInferType) {

--- a/Sources/TypeScriptAST/Component/ASTVisitor.swift
+++ b/Sources/TypeScriptAST/Component/ASTVisitor.swift
@@ -148,6 +148,8 @@ open class ASTVisitor {
     open func visitPost(`try`: TSTryStmt) {}
     open func visit(array: TSArrayType) -> Bool { defaultVisitResult }
     open func visitPost(array: TSArrayType) {}
+    open func visit(conditional: TSConditionalType) -> Bool { defaultVisitResult }
+    open func visitPost(conditional: TSConditionalType) {}
     open func visit(custom: TSCustomType) -> Bool { defaultVisitResult }
     open func visitPost(custom: TSCustomType) {}
     open func visit(dictionary: TSDictionaryType) -> Bool { defaultVisitResult }
@@ -214,6 +216,7 @@ open class ASTVisitor {
         case let x as TSThrowStmt: visitImpl(throw: x)
         case let x as TSTryStmt: visitImpl(try: x)
         case let x as TSArrayType: visitImpl(array: x)
+        case let x as TSConditionalType: visitImpl(conditional: x)
         case let x as TSCustomType: visitImpl(custom: x)
         case let x as TSDictionaryType: visitImpl(dictionary: x)
         case let x as TSFunctionType: visitImpl(function: x)
@@ -497,6 +500,15 @@ open class ASTVisitor {
         guard visit(array: array) else { return }
         walk(array.element)
         visitPost(array: array)
+    }
+
+    private func visitImpl(conditional: TSConditionalType) {
+        guard visit(conditional: conditional) else { return }
+        walk(conditional.check)
+        walk(conditional.extends)
+        walk(conditional.true)
+        walk(conditional.false)
+        visitPost(conditional: conditional)
     }
 
     private func visitImpl(custom: TSCustomType) {

--- a/Sources/TypeScriptAST/Dependency/ScanDependency.swift
+++ b/Sources/TypeScriptAST/Dependency/ScanDependency.swift
@@ -192,12 +192,13 @@ private final class Impl: ASTVisitor {
     }
 
     override func visit(conditional: TSConditionalType) -> Bool {
+        walk(conditional.check)
         push()
-        return true
-    }
-
-    override func visitPost(conditional: TSConditionalType) {
+        walk(conditional.extends)
+        walk(conditional.true)
         pop()
+        walk(conditional.false)
+        return false
     }
 
     override func visit(custom: TSCustomType) -> Bool {

--- a/Sources/TypeScriptAST/Dependency/ScanDependency.swift
+++ b/Sources/TypeScriptAST/Dependency/ScanDependency.swift
@@ -191,9 +191,13 @@ private final class Impl: ASTVisitor {
         return true
     }
 
-    override func visit(ident: TSIdentType) -> Bool {
-        use(ident.name)
+    override func visit(conditional: TSConditionalType) -> Bool {
+        push()
         return true
+    }
+
+    override func visitPost(conditional: TSConditionalType) {
+        pop()
     }
 
     override func visit(custom: TSCustomType) -> Bool {
@@ -206,6 +210,16 @@ private final class Impl: ASTVisitor {
     override func visit(function: TSFunctionType) -> Bool {
         push()
         addNames(function.genericParams)
+        return true
+    }
+
+    override func visit(ident: TSIdentType) -> Bool {
+        use(ident.name)
+        return true
+    }
+
+    override func visit(infer: TSInferType) -> Bool {
+        addNames([infer.name])
         return true
     }
 

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -747,6 +747,7 @@ public final class ASTPrinter: ASTVisitor {
             switch array.element {
             case is TSUnionType: return true
             case is TSIntersectionType: return true
+            case is TSConditionalType: return true
             default: return false
             }
         }()
@@ -755,6 +756,17 @@ public final class ASTPrinter: ASTVisitor {
             walk(array.element)
         }
         printer.write("[]")
+        return false
+    }
+
+    public override func visit(conditional: TSConditionalType) -> Bool {
+        walk(conditional.check)
+        printer.write(" extends ")
+        walk(conditional.extends)
+        printer.write(" ? ")
+        walk(conditional.true)
+        printer.write(" : ")
+        walk(conditional.false)
         return false
     }
 

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -748,6 +748,7 @@ public final class ASTPrinter: ASTVisitor {
             case is TSUnionType: return true
             case is TSIntersectionType: return true
             case is TSConditionalType: return true
+            case is TSInferType: return true
             default: return false
             }
         }()
@@ -813,6 +814,12 @@ public final class ASTPrinter: ASTVisitor {
     public override func visit(ident: TSIdentType) -> Bool {
         printer.write(ident.name)
         write(genericArgs: ident.genericArgs)
+        return false
+    }
+
+    public override func visit(infer: TSInferType) -> Bool {
+        printer.write("infer ")
+        printer.write(infer.name)
         return false
     }
 

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -817,6 +817,14 @@ public final class ASTPrinter: ASTVisitor {
         return false
     }
 
+    public override func visit(indexedAccess: TSIndexedAccessType) -> Bool {
+        walk(indexedAccess.base)
+        printer.write("[")
+        walk(indexedAccess.index)
+        printer.write("]")
+        return false
+    }
+
     public override func visit(infer: TSInferType) -> Bool {
         printer.write("infer ")
         printer.write(infer.name)

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -831,6 +831,11 @@ public final class ASTPrinter: ASTVisitor {
         return false
     }
 
+    public override func visit(numberLiteral: TSNumberLiteralType) -> Bool {
+        printer.write(numberLiteral.text)
+        return false
+    }
+
     public override func visit(object: TSObjectType) -> Bool {
         nest(bracket: "{") {
             write(array: object.fields, multilineMode: .multiline) {

--- a/Sources/codegen/Definitions.swift
+++ b/Sources/codegen/Definitions.swift
@@ -145,6 +145,9 @@ struct Definitions {
         .init(.type, "array", children: [
             "element"
         ]),
+        .init(.type, "conditional", children: [
+            "check", "extends", "true", "false"
+        ]),
         .init(.type, "custom"),
         .init(.type, "dictionary", children: [
             "value"

--- a/Sources/codegen/Definitions.swift
+++ b/Sources/codegen/Definitions.swift
@@ -158,6 +158,9 @@ struct Definitions {
         .init(.type, "ident", children: [
             "genericArgs"
         ]),
+        .init(.type, "indexedAccess", children: [
+            "base", "index"
+        ]),
         .init(.type, "infer"),
         .init(.type, "intersection", children: [
             "elements"

--- a/Sources/codegen/Definitions.swift
+++ b/Sources/codegen/Definitions.swift
@@ -158,6 +158,7 @@ struct Definitions {
         .init(.type, "ident", children: [
             "genericArgs"
         ]),
+        .init(.type, "infer"),
         .init(.type, "intersection", children: [
             "elements"
         ]),

--- a/Sources/codegen/Definitions.swift
+++ b/Sources/codegen/Definitions.swift
@@ -164,6 +164,7 @@ struct Definitions {
         .init(.type, "member", children: [
             "base", "genericArgs"
         ]),
+        .init(.type, "numberLiteral"),
         .init(.type, "object", children: [
             "fields"
         ]),

--- a/Tests/TypeScriptASTTests/PrintTypeTests.swift
+++ b/Tests/TypeScriptASTTests/PrintTypeTests.swift
@@ -308,4 +308,18 @@ final class PrintTypeTests: TestCaseBase {
             """
         )
     }
+
+    func testInfer() throws {
+        let s = TSConditionalType(
+            TSIdentType("T"),
+            extends: TSArrayType(TSInferType(name: "I")),
+            true: TSIdentType("I"),
+            false: TSIdentType("T")
+        )
+        assertPrint(
+            s, """
+            T extends (infer I)[] ? I : T
+            """
+        )
+    }
 }

--- a/Tests/TypeScriptASTTests/PrintTypeTests.swift
+++ b/Tests/TypeScriptASTTests/PrintTypeTests.swift
@@ -322,4 +322,14 @@ final class PrintTypeTests: TestCaseBase {
             """
         )
     }
+
+    func testIndexedAccess() throws {
+        let s = TSIndexedAccessType(TSIdentType("A"), index: TSStringLiteralType("b"))
+
+        assertPrint(
+            s, """
+            A["b"]
+            """
+        )
+    }
 }

--- a/Tests/TypeScriptASTTests/PrintTypeTests.swift
+++ b/Tests/TypeScriptASTTests/PrintTypeTests.swift
@@ -115,6 +115,11 @@ final class PrintTypeTests: TestCaseBase {
         )
 
         assertPrint(
+            TSArrayType(TSConditionalType(TSIdentType("A"), extends: TSIdentType("B"), true: TSIdentType("C"), false: TSIdentType("D"))),
+            "(A extends B ? C : D)[]"
+        )
+
+        assertPrint(
             TSArrayType(TSUnionType([
                 TSIdentType("A"),
                 TSIdentType("B"),
@@ -282,6 +287,16 @@ final class PrintTypeTests: TestCaseBase {
             string & {
                 S: never;
             }
+            """
+        )
+    }
+
+    func testConditional() throws {
+        let s = TSConditionalType(TSIdentType("A"), extends: TSIdentType("B"), true: TSIdentType("C"), false: TSIdentType("D"))
+
+        assertPrint(
+            s, """
+            A extends B ? C : D
             """
         )
     }

--- a/Tests/TypeScriptASTTests/PrintTypeTests.swift
+++ b/Tests/TypeScriptASTTests/PrintTypeTests.swift
@@ -137,6 +137,14 @@ final class PrintTypeTests: TestCaseBase {
         )
     }
 
+    func testNumberLiteral() throws {
+        assertPrint(TSNumberLiteralType(0),
+            """
+            0
+            """
+        )
+    }
+
     func testStringLiteral() throws {
         assertPrint(TSStringLiteralType("aaa"),
             """

--- a/Tests/TypeScriptASTTests/ScanDependencyTests.swift
+++ b/Tests/TypeScriptASTTests/ScanDependencyTests.swift
@@ -459,4 +459,28 @@ final class ScanDependencyTests: TestCaseBase {
 
         XCTAssertEqual(Set(s.scanDependency()), [])
     }
+
+    func testInferType2() {
+        let s = TSSourceFile([
+            TSTypeDecl(
+                name: "F",
+                genericParams: ["T"],
+                type: TSConditionalType(
+                    TSIdentType("T"),
+                    extends: TSArrayType(TSInferType(name: "I")),
+                    true: TSIdentType("T"),
+                    false: TSIdentType("I")
+                )
+            )
+        ])
+
+        assertPrint(
+            s, """
+            type F<T> = T extends (infer I)[] ? T : I;
+
+            """
+        )
+
+        XCTAssertEqual(Set(s.scanDependency()), ["I"])
+    }
 }

--- a/Tests/TypeScriptASTTests/ScanDependencyTests.swift
+++ b/Tests/TypeScriptASTTests/ScanDependencyTests.swift
@@ -435,4 +435,28 @@ final class ScanDependencyTests: TestCaseBase {
 
         XCTAssertEqual(Set(s.scanDependency()), ["U"])
     }
+
+    func testInferType() {
+        let s = TSSourceFile([
+            TSTypeDecl(
+                name: "F",
+                genericParams: ["T"],
+                type: TSConditionalType(
+                    TSIdentType("T"),
+                    extends: TSArrayType(TSInferType(name: "I")),
+                    true: TSIdentType("I"),
+                    false: TSIdentType("T")
+                )
+            )
+        ])
+
+        assertPrint(
+            s, """
+            type F<T> = T extends (infer I)[] ? I : T;
+
+            """
+        )
+
+        XCTAssertEqual(Set(s.scanDependency()), [])
+    }
 }


### PR DESCRIPTION
以下の型を追加します

- `T extends A ? string : number` (ConditionalType)
- `0` (NumberLiteralType)
- `infer T` (InferType)
- `A[0]` (IndexedAccessType)