### PR TITLE
Add MappedType and KeyofType

### DIFF
--- a/Sources/ASTNodeModule/Type/TSKeyofType.swift
+++ b/Sources/ASTNodeModule/Type/TSKeyofType.swift
@@ -1,0 +1,12 @@
+public final class TSKeyofType: _TSType {
+    public init(_ type: any TSType) {
+        self.type = type
+    }
+
+    public private(set) unowned var parent: (any ASTNode)?
+    internal func _setParent(_ newValue: (any ASTNode)?) {
+        parent = newValue
+    }
+
+    @AnyTSTypeStorage public var type: any TSType
+}

--- a/Sources/ASTNodeModule/Type/TSMappedType.swift
+++ b/Sources/ASTNodeModule/Type/TSMappedType.swift
@@ -8,7 +8,7 @@ public final class TSMappedType: _TSType {
         readonly: ModifierOperation? = nil,
         _ name: String,
         in constraint: any TSType,
-        nameType: (any TSType)? = nil,
+        as nameType: (any TSType)? = nil,
         optional: ModifierOperation? = nil,
         value: any TSType
     ) {

--- a/Sources/ASTNodeModule/Type/TSMappedType.swift
+++ b/Sources/ASTNodeModule/Type/TSMappedType.swift
@@ -1,0 +1,34 @@
+public final class TSMappedType: _TSType {
+    public enum ModifierOperation {
+        case add
+        case remove
+    }
+
+    public init(
+        readonly: ModifierOperation? = nil,
+        _ name: String,
+        in constraint: any TSType,
+        nameType: (any TSType)? = nil,
+        optional: ModifierOperation? = nil,
+        value: any TSType
+    ) {
+        self.readonly = readonly
+        self.name = name
+        self.constraint = constraint
+        self.nameType = nameType
+        self.optional = optional
+        self.value = value
+    }
+
+    public private(set) unowned var parent: (any ASTNode)?
+    internal func _setParent(_ newValue: (any ASTNode)?) {
+        parent = newValue
+    }
+
+    public var readonly: ModifierOperation?
+    public var name: String
+    @AnyTSTypeStorage public var constraint: any TSType
+    @AnyTSTypeOptionalStorage public var nameType: (any TSType)?
+    public var optional: ModifierOperation?
+    @AnyTSTypeStorage public var value: any TSType
+}

--- a/Sources/ASTNodeModule/Type/TSType.swift
+++ b/Sources/ASTNodeModule/Type/TSType.swift
@@ -15,6 +15,7 @@ extension TSType {
     public var asIndexedAccess: TSIndexedAccessType? { self as? TSIndexedAccessType }
     public var asInfer: TSInferType? { self as? TSInferType }
     public var asIntersection: TSIntersectionType? { self as? TSIntersectionType }
+    public var asMapped: TSMappedType? { self as? TSMappedType }
     public var asMember: TSMemberType? { self as? TSMemberType }
     public var asNumberLiteral: TSNumberLiteralType? { self as? TSNumberLiteralType }
     public var asObject: TSObjectType? { self as? TSObjectType }

--- a/Sources/ASTNodeModule/Type/TSType.swift
+++ b/Sources/ASTNodeModule/Type/TSType.swift
@@ -15,6 +15,7 @@ extension TSType {
     public var asIndexedAccess: TSIndexedAccessType? { self as? TSIndexedAccessType }
     public var asInfer: TSInferType? { self as? TSInferType }
     public var asIntersection: TSIntersectionType? { self as? TSIntersectionType }
+    public var asKeyof: TSKeyofType? { self as? TSKeyofType }
     public var asMapped: TSMappedType? { self as? TSMappedType }
     public var asMember: TSMemberType? { self as? TSMemberType }
     public var asNumberLiteral: TSNumberLiteralType? { self as? TSNumberLiteralType }

--- a/Sources/TypeScriptAST/Component/ASTVisitor.swift
+++ b/Sources/TypeScriptAST/Component/ASTVisitor.swift
@@ -169,6 +169,8 @@ open class ASTVisitor {
     open func visitPost(infer: TSInferType) {}
     open func visit(intersection: TSIntersectionType) -> Bool { defaultVisitResult }
     open func visitPost(intersection: TSIntersectionType) {}
+    open func visit(keyof: TSKeyofType) -> Bool { defaultVisitResult }
+    open func visitPost(keyof: TSKeyofType) {}
     open func visit(mapped: TSMappedType) -> Bool { defaultVisitResult }
     open func visitPost(mapped: TSMappedType) {}
     open func visit(member: TSMemberType) -> Bool { defaultVisitResult }
@@ -237,6 +239,7 @@ open class ASTVisitor {
         case let x as TSIndexedAccessType: visitImpl(indexedAccess: x)
         case let x as TSInferType: visitImpl(infer: x)
         case let x as TSIntersectionType: visitImpl(intersection: x)
+        case let x as TSKeyofType: visitImpl(keyof: x)
         case let x as TSMappedType: visitImpl(mapped: x)
         case let x as TSMemberType: visitImpl(member: x)
         case let x as TSNumberLiteralType: visitImpl(numberLiteral: x)
@@ -568,6 +571,12 @@ open class ASTVisitor {
         guard visit(intersection: intersection) else { return }
         walk(intersection.elements)
         visitPost(intersection: intersection)
+    }
+
+    private func visitImpl(keyof: TSKeyofType) {
+        guard visit(keyof: keyof) else { return }
+        walk(keyof.type)
+        visitPost(keyof: keyof)
     }
 
     private func visitImpl(mapped: TSMappedType) {

--- a/Sources/TypeScriptAST/Component/ASTVisitor.swift
+++ b/Sources/TypeScriptAST/Component/ASTVisitor.swift
@@ -169,6 +169,8 @@ open class ASTVisitor {
     open func visitPost(infer: TSInferType) {}
     open func visit(intersection: TSIntersectionType) -> Bool { defaultVisitResult }
     open func visitPost(intersection: TSIntersectionType) {}
+    open func visit(mapped: TSMappedType) -> Bool { defaultVisitResult }
+    open func visitPost(mapped: TSMappedType) {}
     open func visit(member: TSMemberType) -> Bool { defaultVisitResult }
     open func visitPost(member: TSMemberType) {}
     open func visit(numberLiteral: TSNumberLiteralType) -> Bool { defaultVisitResult }
@@ -235,6 +237,7 @@ open class ASTVisitor {
         case let x as TSIndexedAccessType: visitImpl(indexedAccess: x)
         case let x as TSInferType: visitImpl(infer: x)
         case let x as TSIntersectionType: visitImpl(intersection: x)
+        case let x as TSMappedType: visitImpl(mapped: x)
         case let x as TSMemberType: visitImpl(member: x)
         case let x as TSNumberLiteralType: visitImpl(numberLiteral: x)
         case let x as TSObjectType: visitImpl(object: x)
@@ -565,6 +568,13 @@ open class ASTVisitor {
         guard visit(intersection: intersection) else { return }
         walk(intersection.elements)
         visitPost(intersection: intersection)
+    }
+
+    private func visitImpl(mapped: TSMappedType) {
+        guard visit(mapped: mapped) else { return }
+        walk(mapped.constraint)
+        walk(mapped.value)
+        visitPost(mapped: mapped)
     }
 
     private func visitImpl(member: TSMemberType) {

--- a/Sources/TypeScriptAST/Component/ASTVisitor.swift
+++ b/Sources/TypeScriptAST/Component/ASTVisitor.swift
@@ -582,6 +582,7 @@ open class ASTVisitor {
     private func visitImpl(mapped: TSMappedType) {
         guard visit(mapped: mapped) else { return }
         walk(mapped.constraint)
+        walk(mapped.nameType)
         walk(mapped.value)
         visitPost(mapped: mapped)
     }

--- a/Sources/TypeScriptAST/Dependency/ScanDependency.swift
+++ b/Sources/TypeScriptAST/Dependency/ScanDependency.swift
@@ -227,4 +227,14 @@ private final class Impl: ASTVisitor {
     override func visitPost(function: TSFunctionType) {
         pop()
     }
+
+    override func visit(mapped: TSMappedType) -> Bool {
+        push()
+        addNames([mapped.name])
+        return true
+    }
+
+    override func visitPost(mapped: TSMappedType) {
+        pop()
+    }
 }

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -841,6 +841,38 @@ public final class ASTPrinter: ASTVisitor {
         return false
     }
 
+    public override func visit(mapped: TSMappedType) -> Bool {
+        nest(bracket: "{") {
+            printer.push(newline: true)
+            if let readonly = mapped.readonly {
+                if readonly == .remove {
+                    printer.write(space: " ", "-")
+                }
+                printer.write(space: " ", "readonly")
+            }
+            printer.write(space: " ", "[")
+            printer.write(mapped.name)
+            printer.write(" in ")
+            walk(mapped.constraint)
+            if let name = mapped.nameType {
+                printer.write(space: " ", "as ")
+                walk(name)
+            }
+            printer.write("]")
+            if let optional = mapped.optional {
+                if optional == .remove {
+                    printer.write("-")
+                }
+                printer.write("?")
+            }
+            printer.write(": ")
+            walk(mapped.value)
+            printer.write(";")
+            printer.pop()
+        }
+        return false
+    }
+
     public override func visit(member: TSMemberType) -> Bool {
         walk(member.base)
         printer.write(".")

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -841,6 +841,12 @@ public final class ASTPrinter: ASTVisitor {
         return false
     }
 
+    public override func visit(keyof: TSKeyofType) -> Bool {
+        printer.write("keyof ")
+        walk(keyof.type)
+        return false
+    }
+
     public override func visit(mapped: TSMappedType) -> Bool {
         nest(bracket: "{") {
             printer.push(newline: true)

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -852,9 +852,9 @@ public final class ASTPrinter: ASTVisitor {
             printer.push(newline: true)
             if let readonly = mapped.readonly {
                 if readonly == .remove {
-                    printer.write(space: " ", "-")
+                    printer.write("-")
                 }
-                printer.write(space: " ", "readonly")
+                printer.write("readonly")
             }
             printer.write(space: " ", "[")
             printer.write(mapped.name)

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -752,6 +752,7 @@ public final class ASTPrinter: ASTVisitor {
             case is TSIntersectionType: return true
             case is TSConditionalType: return true
             case is TSInferType: return true
+            case is TSKeyofType: return true
             default: return false
             }
         }()

--- a/Sources/codegen/Definitions.swift
+++ b/Sources/codegen/Definitions.swift
@@ -169,7 +169,7 @@ struct Definitions {
             "type"
         ]),
         .init(.type, "mapped", children: [
-            "constraint", "value"
+            "constraint", "nameType", "value"
         ]),
         .init(.type, "member", children: [
             "base", "genericArgs"

--- a/Sources/codegen/Definitions.swift
+++ b/Sources/codegen/Definitions.swift
@@ -165,6 +165,9 @@ struct Definitions {
         .init(.type, "intersection", children: [
             "elements"
         ]),
+        .init(.type, "keyof", children: [
+            "type"
+        ]),
         .init(.type, "mapped", children: [
             "constraint", "value"
         ]),

--- a/Sources/codegen/Definitions.swift
+++ b/Sources/codegen/Definitions.swift
@@ -165,6 +165,9 @@ struct Definitions {
         .init(.type, "intersection", children: [
             "elements"
         ]),
+        .init(.type, "mapped", children: [
+            "constraint", "value"
+        ]),
         .init(.type, "member", children: [
             "base", "genericArgs"
         ]),

--- a/Tests/TypeScriptASTTests/PrintTypeTests.swift
+++ b/Tests/TypeScriptASTTests/PrintTypeTests.swift
@@ -347,4 +347,11 @@ final class PrintTypeTests: TestCaseBase {
             """
         )
     }
+
+    func testKeyof() throws {
+        assertPrint(
+            TSKeyofType(TSIdentType("T")),
+            "keyof T"
+        )
+    }
 }

--- a/Tests/TypeScriptASTTests/PrintTypeTests.swift
+++ b/Tests/TypeScriptASTTests/PrintTypeTests.swift
@@ -336,4 +336,15 @@ final class PrintTypeTests: TestCaseBase {
             """
         )
     }
+
+    func testMapped() throws {
+        assertPrint(
+            TSMappedType("P", in: TSIdentType("T"), value: TSIdentType.number),
+            """
+            {
+                [P in T]: number;
+            }
+            """
+        )
+    }
 }

--- a/Tests/TypeScriptASTTests/PrintTypeTests.swift
+++ b/Tests/TypeScriptASTTests/PrintTypeTests.swift
@@ -346,6 +346,35 @@ final class PrintTypeTests: TestCaseBase {
             }
             """
         )
+
+        assertPrint(
+            TSMappedType(
+                readonly: .remove,
+                "P",
+                in: TSKeyofType(TSIdentType("T")),
+                optional: .remove,
+                value: TSIndexedAccessType(TSIdentType("T"), index: TSIdentType("P"))
+            ),
+            """
+            {
+                -readonly [P in keyof T]-?: T[P];
+            }
+            """
+        )
+
+        assertPrint(
+            TSMappedType(
+                "P",
+                in: TSKeyofType(TSIdentType("T")),
+                as: TSIdentType("K"),
+                value: TSIndexedAccessType(TSIdentType("T"), index: TSIdentType("P"))
+            ),
+            """
+            {
+                [P in keyof T as K]: T[P];
+            }
+            """
+        )
     }
 
     func testKeyof() throws {

--- a/Tests/TypeScriptASTTests/ScanDependencyTests.swift
+++ b/Tests/TypeScriptASTTests/ScanDependencyTests.swift
@@ -483,4 +483,30 @@ final class ScanDependencyTests: TestCaseBase {
 
         XCTAssertEqual(Set(s.scanDependency()), ["I"])
     }
+
+    func testMappedType() {
+        let s = TSSourceFile([
+            TSTypeDecl(
+                name: "E",
+                genericParams: ["T"],
+                type: TSMappedType(
+                    "P",
+                    in: TSKeyofType(TSIdentType("T")),
+                    as: TSIdentType("Exclude", genericArgs: [TSIdentType("P"), TSStringLiteralType("kind")]),
+                    value: TSIndexedAccessType(TSIdentType("T"), index: TSIdentType("P"))
+                )
+            ),
+        ])
+
+        assertPrint(
+            s, """
+            type E<T> = {
+                [P in keyof T as Exclude<P, "kind">]: T[P];
+            };
+            
+            """
+        )
+
+        XCTAssertEqual(Set(s.scanDependency()), ["Exclude"])
+    }
 }


### PR DESCRIPTION
#19 の続きです。先に #19 を見てください。

以下の型を追加します。

- `{ [P in T]: string }` (MappedType)
- `keyof T` (KeyofType)