### PR TITLE
Add conditional generic parameter

### DIFF
--- a/Sources/ASTNodeModule/Decl/TSClassDecl.swift
+++ b/Sources/ASTNodeModule/Decl/TSClassDecl.swift
@@ -2,7 +2,7 @@ public final class TSClassDecl: _TSDecl {
     public init(
         modifiers: [TSDeclModifier] = [],
         name: String,
-        genericParams: [String] = [],
+        genericParams: [TSTypeParameterNode] = [],
         extends: TSIdentType? = nil,
         implements: [TSIdentType] = [],
         body: TSBlockStmt
@@ -22,7 +22,7 @@ public final class TSClassDecl: _TSDecl {
 
     public var modifiers: [TSDeclModifier]
     public var name: String
-    public var genericParams: [String]
+    public var genericParams: [TSTypeParameterNode]
     @ASTNodeOptionalStorage public var extends: TSIdentType?
     @ASTNodeArrayStorage public var implements: [TSIdentType]
     @ASTNodeStorage public var body: TSBlockStmt

--- a/Sources/ASTNodeModule/Decl/TSClassDecl.swift
+++ b/Sources/ASTNodeModule/Decl/TSClassDecl.swift
@@ -22,7 +22,7 @@ public final class TSClassDecl: _TSDecl {
 
     public var modifiers: [TSDeclModifier]
     public var name: String
-    public var genericParams: [TSTypeParameterNode]
+    @ASTNodeArrayStorage public var genericParams: [TSTypeParameterNode]
     @ASTNodeOptionalStorage public var extends: TSIdentType?
     @ASTNodeArrayStorage public var implements: [TSIdentType]
     @ASTNodeStorage public var body: TSBlockStmt

--- a/Sources/ASTNodeModule/Decl/TSFunctionDecl.swift
+++ b/Sources/ASTNodeModule/Decl/TSFunctionDecl.swift
@@ -2,7 +2,7 @@ public final class TSFunctionDecl: _TSDecl {
     public init(
         modifiers: [TSDeclModifier] = [],
         name: String,
-        genericParams: [String] = [],
+        genericParams: [TSTypeParameterNode] = [],
         params: [TSFunctionType.Param],
         result: (any TSType)? = nil,
         body: TSBlockStmt
@@ -22,7 +22,7 @@ public final class TSFunctionDecl: _TSDecl {
 
     public var modifiers: [TSDeclModifier]
     public var name: String
-    public var genericParams: [String]
+    public var genericParams: [TSTypeParameterNode]
     public var params: [TSFunctionType.Param] {
         get { _params }
         set {

--- a/Sources/ASTNodeModule/Decl/TSFunctionDecl.swift
+++ b/Sources/ASTNodeModule/Decl/TSFunctionDecl.swift
@@ -22,7 +22,7 @@ public final class TSFunctionDecl: _TSDecl {
 
     public var modifiers: [TSDeclModifier]
     public var name: String
-    public var genericParams: [TSTypeParameterNode]
+    @ASTNodeArrayStorage public var genericParams: [TSTypeParameterNode]
     public var params: [TSFunctionType.Param] {
         get { _params }
         set {

--- a/Sources/ASTNodeModule/Decl/TSInterfaceDecl.swift
+++ b/Sources/ASTNodeModule/Decl/TSInterfaceDecl.swift
@@ -20,7 +20,7 @@ public final class TSInterfaceDecl: _TSDecl {
 
     public var modifiers: [TSDeclModifier]
     public var name: String
-    public var genericParams: [TSTypeParameterNode]
+    @ASTNodeArrayStorage public var genericParams: [TSTypeParameterNode]
     @ASTNodeArrayStorage public var extends: [TSIdentType]
     @ASTNodeStorage public var body: TSBlockStmt
 }

--- a/Sources/ASTNodeModule/Decl/TSInterfaceDecl.swift
+++ b/Sources/ASTNodeModule/Decl/TSInterfaceDecl.swift
@@ -2,7 +2,7 @@ public final class TSInterfaceDecl: _TSDecl {
     public init(
         modifiers: [TSDeclModifier] = [],
         name: String,
-        genericParams: [String] = [],
+        genericParams: [TSTypeParameterNode] = [],
         extends: [TSIdentType] = [],
         body: TSBlockStmt
     ) {
@@ -20,7 +20,7 @@ public final class TSInterfaceDecl: _TSDecl {
 
     public var modifiers: [TSDeclModifier]
     public var name: String
-    public var genericParams: [String]
+    public var genericParams: [TSTypeParameterNode]
     @ASTNodeArrayStorage public var extends: [TSIdentType]
     @ASTNodeStorage public var body: TSBlockStmt
 }

--- a/Sources/ASTNodeModule/Decl/TSMethodDecl.swift
+++ b/Sources/ASTNodeModule/Decl/TSMethodDecl.swift
@@ -3,7 +3,7 @@ public final class TSMethodDecl: _TSDecl {
         modifiers: [TSDeclModifier] = [],
         name: String,
         isOptional: Bool = false,
-        genericParams: [String] = [],
+        genericParams: [TSTypeParameterNode] = [],
         params: [TSFunctionType.Param],
         result: (any TSType)? = nil,
         body: TSBlockStmt? = nil
@@ -25,7 +25,7 @@ public final class TSMethodDecl: _TSDecl {
     public var modifiers: [TSDeclModifier]
     public var name: String
     public var isOptional: Bool
-    public var genericParams: [String]
+    public var genericParams: [TSTypeParameterNode]
     public var params: [TSFunctionType.Param] {
         get { _params }
         set {

--- a/Sources/ASTNodeModule/Decl/TSMethodDecl.swift
+++ b/Sources/ASTNodeModule/Decl/TSMethodDecl.swift
@@ -25,7 +25,7 @@ public final class TSMethodDecl: _TSDecl {
     public var modifiers: [TSDeclModifier]
     public var name: String
     public var isOptional: Bool
-    public var genericParams: [TSTypeParameterNode]
+    @ASTNodeArrayStorage public var genericParams: [TSTypeParameterNode]
     public var params: [TSFunctionType.Param] {
         get { _params }
         set {

--- a/Sources/ASTNodeModule/Decl/TSTypeDecl.swift
+++ b/Sources/ASTNodeModule/Decl/TSTypeDecl.swift
@@ -18,6 +18,6 @@ public final class TSTypeDecl: _TSDecl {
 
     public var modifiers: [TSDeclModifier]
     public var name: String
-    public var genericParams: [TSTypeParameterNode]
+    @ASTNodeArrayStorage public var genericParams: [TSTypeParameterNode]
     @AnyTSTypeStorage public var type: any TSType
 }

--- a/Sources/ASTNodeModule/Decl/TSTypeDecl.swift
+++ b/Sources/ASTNodeModule/Decl/TSTypeDecl.swift
@@ -2,7 +2,7 @@ public final class TSTypeDecl: _TSDecl {
     public init(
         modifiers: [TSDeclModifier] = [],
         name: String,
-        genericParams: [String] = [],
+        genericParams: [TSTypeParameterNode] = [],
         type: any TSType
     ) {
         self.modifiers = modifiers
@@ -18,6 +18,6 @@ public final class TSTypeDecl: _TSDecl {
 
     public var modifiers: [TSDeclModifier]
     public var name: String
-    public var genericParams: [String]
+    public var genericParams: [TSTypeParameterNode]
     @AnyTSTypeStorage public var type: any TSType
 }

--- a/Sources/ASTNodeModule/Expr/TSClosureExpr.swift
+++ b/Sources/ASTNodeModule/Expr/TSClosureExpr.swift
@@ -6,8 +6,8 @@ public final class TSClosureExpr: _TSExpr {
         result: (any TSType)? = nil,
         body: any TSStmt
     ) {
-        self.genericParams = genericParams
         self.hasParen = hasParen
+        self.genericParams = genericParams
         self.params = params
         self.result = result
         self.body = body
@@ -18,7 +18,7 @@ public final class TSClosureExpr: _TSExpr {
         parent = newValue
     }
 
-    public var genericParams: [TSTypeParameterNode]
+    @ASTNodeArrayStorage public var genericParams: [TSTypeParameterNode]
     public var hasParen: Bool
     public var params: [TSFunctionType.Param] {
         get { _params }

--- a/Sources/ASTNodeModule/Expr/TSClosureExpr.swift
+++ b/Sources/ASTNodeModule/Expr/TSClosureExpr.swift
@@ -1,6 +1,6 @@
 public final class TSClosureExpr: _TSExpr {
     public init(
-        genericParams: [String] = [],
+        genericParams: [TSTypeParameterNode] = [],
         hasParen: Bool = true,
         params: [TSFunctionType.Param],
         result: (any TSType)? = nil,
@@ -18,7 +18,7 @@ public final class TSClosureExpr: _TSExpr {
         parent = newValue
     }
 
-    public var genericParams: [String]
+    public var genericParams: [TSTypeParameterNode]
     public var hasParen: Bool
     public var params: [TSFunctionType.Param] {
         get { _params }

--- a/Sources/ASTNodeModule/Node/TSTypeParameterNode.swift
+++ b/Sources/ASTNodeModule/Node/TSTypeParameterNode.swift
@@ -1,0 +1,20 @@
+public final class TSTypeParameterNode: _ASTNode {
+    public init(
+        _ name: String,
+        extends constraint: (any TSType)? = nil,
+        default: (any TSType)? = nil
+    ) {
+        self.name = name
+        self.constraint = constraint
+        self.default = `default`
+    }
+
+    public private(set) unowned var parent: (any ASTNode)?
+    internal func _setParent(_ newValue: (any ASTNode)?) {
+        parent = newValue
+    }
+
+    public var name: String
+    @AnyTSTypeOptionalStorage public var constraint: (any TSType)?
+    @AnyTSTypeOptionalStorage public var `default`: (any TSType)?
+}

--- a/Sources/ASTNodeModule/Type/TSFunctionType.swift
+++ b/Sources/ASTNodeModule/Type/TSFunctionType.swift
@@ -30,7 +30,7 @@ public final class TSFunctionType: _TSType {
         parent = newValue
     }
 
-    public var genericParams: [TSTypeParameterNode]
+    @ASTNodeArrayStorage public var genericParams: [TSTypeParameterNode]
     public var params: [Param] {
         get { _params }
         set {

--- a/Sources/ASTNodeModule/Type/TSFunctionType.swift
+++ b/Sources/ASTNodeModule/Type/TSFunctionType.swift
@@ -16,7 +16,7 @@ public final class TSFunctionType: _TSType {
     }
 
     public init(
-        genericParams: [String] = [],
+        genericParams: [TSTypeParameterNode] = [],
         params: [Param],
         result: any TSType
     ) {
@@ -30,7 +30,7 @@ public final class TSFunctionType: _TSType {
         parent = newValue
     }
 
-    public var genericParams: [String]
+    public var genericParams: [TSTypeParameterNode]
     public var params: [Param] {
         get { _params }
         set {

--- a/Sources/TypeScriptAST/Component/ASTVisitor.swift
+++ b/Sources/TypeScriptAST/Component/ASTVisitor.swift
@@ -266,6 +266,7 @@ open class ASTVisitor {
 
     private func visitImpl(`class`: TSClassDecl) {
         guard visit(class: `class`) else { return }
+        walk(`class`.genericParams)
         walk(`class`.extends)
         walk(`class`.implements)
         walk(`class`.body)
@@ -280,6 +281,7 @@ open class ASTVisitor {
 
     private func visitImpl(function: TSFunctionDecl) {
         guard visit(function: function) else { return }
+        walk(function.genericParams)
         walk(function.params)
         walk(function.result)
         walk(function.body)
@@ -300,6 +302,7 @@ open class ASTVisitor {
 
     private func visitImpl(interface: TSInterfaceDecl) {
         guard visit(interface: interface) else { return }
+        walk(interface.genericParams)
         walk(interface.extends)
         walk(interface.body)
         visitPost(interface: interface)
@@ -307,6 +310,7 @@ open class ASTVisitor {
 
     private func visitImpl(method: TSMethodDecl) {
         guard visit(method: method) else { return }
+        walk(method.genericParams)
         walk(method.params)
         walk(method.result)
         walk(method.body)
@@ -327,6 +331,7 @@ open class ASTVisitor {
 
     private func visitImpl(type: TSTypeDecl) {
         guard visit(type: type) else { return }
+        walk(type.genericParams)
         walk(type.type)
         visitPost(type: type)
     }
@@ -378,6 +383,7 @@ open class ASTVisitor {
 
     private func visitImpl(closure: TSClosureExpr) {
         guard visit(closure: closure) else { return }
+        walk(closure.genericParams)
         walk(closure.params)
         walk(closure.result)
         walk(closure.body)
@@ -557,6 +563,7 @@ open class ASTVisitor {
 
     private func visitImpl(function: TSFunctionType) {
         guard visit(function: function) else { return }
+        walk(function.genericParams)
         walk(function.params)
         walk(function.result)
         visitPost(function: function)

--- a/Sources/TypeScriptAST/Component/ASTVisitor.swift
+++ b/Sources/TypeScriptAST/Component/ASTVisitor.swift
@@ -69,6 +69,8 @@ open class ASTVisitor {
     }
 
     // @codegen(visit)
+    open func visit(typeParameter: TSTypeParameterNode) -> Bool { defaultVisitResult }
+    open func visitPost(typeParameter: TSTypeParameterNode) {}
     open func visit(`class`: TSClassDecl) -> Bool { defaultVisitResult }
     open func visitPost(`class`: TSClassDecl) {}
     open func visit(field: TSFieldDecl) -> Bool { defaultVisitResult }
@@ -190,6 +192,7 @@ open class ASTVisitor {
     // @codegen(dispatch)
     private func dispatch(_ node: any ASTNode) {
         switch node {
+        case let x as TSTypeParameterNode: visitImpl(typeParameter: x)
         case let x as TSClassDecl: visitImpl(class: x)
         case let x as TSFieldDecl: visitImpl(field: x)
         case let x as TSFunctionDecl: visitImpl(function: x)
@@ -254,6 +257,13 @@ open class ASTVisitor {
     // @end
 
     // @codegen(visitImpl)
+    private func visitImpl(typeParameter: TSTypeParameterNode) {
+        guard visit(typeParameter: typeParameter) else { return }
+        walk(typeParameter.constraint)
+        walk(typeParameter.default)
+        visitPost(typeParameter: typeParameter)
+    }
+
     private func visitImpl(`class`: TSClassDecl) {
         guard visit(class: `class`) else { return }
         walk(`class`.extends)

--- a/Sources/TypeScriptAST/Dependency/ScanDependency.swift
+++ b/Sources/TypeScriptAST/Dependency/ScanDependency.swift
@@ -66,7 +66,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(class: TSClassDecl) -> Bool {
         push()
-        addNames(`class`.genericParams)
+        addNames(`class`.genericParams.map(\.name))
         return true
     }
 
@@ -76,7 +76,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(interface: TSInterfaceDecl) -> Bool {
         push()
-        addNames(interface.genericParams)
+        addNames(interface.genericParams.map(\.name))
         return true
     }
 
@@ -86,7 +86,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(function: TSFunctionDecl) -> Bool {
         push()
-        addNames(function.genericParams)
+        addNames(function.genericParams.map(\.name))
         addNames(function.params.map { $0.name })
         return true
     }
@@ -97,7 +97,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(method: TSMethodDecl) -> Bool {
         push()
-        addNames(method.genericParams)
+        addNames(method.genericParams.map(\.name))
         addNames(method.params.map { $0.name })
         return true
     }
@@ -108,7 +108,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(type: TSTypeDecl) -> Bool {
         push()
-        addNames(type.genericParams)
+        addNames(type.genericParams.map(\.name))
         return true
     }
 
@@ -160,7 +160,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(closure: TSClosureExpr) -> Bool {
         push()
-        addNames(closure.genericParams)
+        addNames(closure.genericParams.map(\.name))
         addNames(closure.params.map { $0.name })
         return true
     }
@@ -210,7 +210,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(function: TSFunctionType) -> Bool {
         push()
-        addNames(function.genericParams)
+        addNames(function.genericParams.map(\.name))
         return true
     }
 

--- a/Sources/TypeScriptAST/Dependency/ScanDependency.swift
+++ b/Sources/TypeScriptAST/Dependency/ScanDependency.swift
@@ -44,16 +44,8 @@ private final class Impl: ASTVisitor {
         dependencies.insert(name)
     }
 
-    private func use(genericParams: [TSTypeParameterNode]) {
+    private func addNames(_ genericParams: [TSTypeParameterNode]) {
         addNames(genericParams.map(\.name))
-        for genericParam in genericParams {
-            if let constraint = genericParam.constraint {
-                walk(constraint)
-            }
-            if let `default` = genericParam.default {
-                walk(`default`)
-            }
-        }
     }
 
     override func visit(sourceFile: TSSourceFile) -> Bool {
@@ -78,7 +70,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(class: TSClassDecl) -> Bool {
         push()
-        use(genericParams: `class`.genericParams)
+        addNames(`class`.genericParams)
         return true
     }
 
@@ -88,7 +80,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(interface: TSInterfaceDecl) -> Bool {
         push()
-        use(genericParams: interface.genericParams)
+        addNames(interface.genericParams)
         return true
     }
 
@@ -98,7 +90,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(function: TSFunctionDecl) -> Bool {
         push()
-        use(genericParams: function.genericParams)
+        addNames(function.genericParams)
         addNames(function.params.map { $0.name })
         return true
     }
@@ -109,7 +101,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(method: TSMethodDecl) -> Bool {
         push()
-        use(genericParams: method.genericParams)
+        addNames(method.genericParams)
         addNames(method.params.map { $0.name })
         return true
     }
@@ -120,7 +112,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(type: TSTypeDecl) -> Bool {
         push()
-        use(genericParams: type.genericParams)
+        addNames(type.genericParams)
         return true
     }
 
@@ -172,7 +164,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(closure: TSClosureExpr) -> Bool {
         push()
-        use(genericParams: closure.genericParams)
+        addNames(closure.genericParams)
         addNames(closure.params.map { $0.name })
         return true
     }
@@ -222,7 +214,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(function: TSFunctionType) -> Bool {
         push()
-        use(genericParams: function.genericParams)
+        addNames(function.genericParams)
         return true
     }
 

--- a/Sources/TypeScriptAST/Dependency/ScanDependency.swift
+++ b/Sources/TypeScriptAST/Dependency/ScanDependency.swift
@@ -44,6 +44,18 @@ private final class Impl: ASTVisitor {
         dependencies.insert(name)
     }
 
+    private func use(genericParams: [TSTypeParameterNode]) {
+        addNames(genericParams.map(\.name))
+        for genericParam in genericParams {
+            if let constraint = genericParam.constraint {
+                walk(constraint)
+            }
+            if let `default` = genericParam.default {
+                walk(`default`)
+            }
+        }
+    }
+
     override func visit(sourceFile: TSSourceFile) -> Bool {
         push()
         addNames(sourceFile.memberDeclaredNames)
@@ -66,7 +78,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(class: TSClassDecl) -> Bool {
         push()
-        addNames(`class`.genericParams.map(\.name))
+        use(genericParams: `class`.genericParams)
         return true
     }
 
@@ -76,7 +88,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(interface: TSInterfaceDecl) -> Bool {
         push()
-        addNames(interface.genericParams.map(\.name))
+        use(genericParams: interface.genericParams)
         return true
     }
 
@@ -86,7 +98,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(function: TSFunctionDecl) -> Bool {
         push()
-        addNames(function.genericParams.map(\.name))
+        use(genericParams: function.genericParams)
         addNames(function.params.map { $0.name })
         return true
     }
@@ -97,7 +109,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(method: TSMethodDecl) -> Bool {
         push()
-        addNames(method.genericParams.map(\.name))
+        use(genericParams: method.genericParams)
         addNames(method.params.map { $0.name })
         return true
     }
@@ -108,7 +120,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(type: TSTypeDecl) -> Bool {
         push()
-        addNames(type.genericParams.map(\.name))
+        use(genericParams: type.genericParams)
         return true
     }
 
@@ -160,7 +172,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(closure: TSClosureExpr) -> Bool {
         push()
-        addNames(closure.genericParams.map(\.name))
+        use(genericParams: closure.genericParams)
         addNames(closure.params.map { $0.name })
         return true
     }
@@ -210,7 +222,7 @@ private final class Impl: ASTVisitor {
 
     override func visit(function: TSFunctionType) -> Bool {
         push()
-        addNames(function.genericParams.map(\.name))
+        use(genericParams: function.genericParams)
         return true
     }
 

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -271,9 +271,15 @@ public final class ASTPrinter: ASTVisitor {
     // MARK: - node
 
     public override func visit(typeParameter: TSTypeParameterNode) -> Bool {
-        // TODO:
         printer.write(typeParameter.name)
-
+        if let constraint = typeParameter.constraint {
+            printer.write(" extends ")
+            walk(constraint)
+        }
+        if let `default` = typeParameter.default {
+            printer.write(" = ")
+            walk(`default`)
+        }
         return false
     }
 

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -259,13 +259,22 @@ public final class ASTPrinter: ASTVisitor {
         }
     }
 
-    private func write(genericParams: [String]) {
+    private func write(genericParams: [TSTypeParameterNode]) {
         if genericParams.isEmpty { return }
         nest(bracket: "<") {
             write(array: genericParams, separator: ",") {
-                printer.write($0)
+                walk($0)
             }
         }
+    }
+
+    // MARK: - node
+
+    public override func visit(typeParameter: TSTypeParameterNode) -> Bool {
+        // TODO:
+        printer.write(typeParameter.name)
+
+        return false
     }
 
     // MARK: - decl
@@ -470,7 +479,7 @@ public final class ASTPrinter: ASTVisitor {
         switch closure.genericParams.count {
         case 1:
             nest(bracket: "<") {
-                printer.write(closure.genericParams[0])
+                walk(closure.genericParams[0])
                 printer.write(",")
             }
         default:

--- a/Sources/codegen/Definitions.swift
+++ b/Sources/codegen/Definitions.swift
@@ -1,5 +1,6 @@
 struct Node {
     enum Kind: String, CaseIterable {
+        case node
         case decl
         case expr
         case stmt
@@ -32,6 +33,9 @@ struct Node {
 
 struct Definitions {
     var nodes: [Node] = [
+        .init(.node, "typeParameter", children: [
+            "constraint", "default"
+        ]),
         .init(.decl, "class", children: [
             "extends", "implements", "body"
         ]),

--- a/Sources/codegen/Definitions.swift
+++ b/Sources/codegen/Definitions.swift
@@ -37,23 +37,23 @@ struct Definitions {
             "constraint", "default"
         ]),
         .init(.decl, "class", children: [
-            "extends", "implements", "body"
+            "genericParams", "extends", "implements", "body"
         ]),
         .init(.decl, "field", children: [
             "type"
         ]),
         .init(.decl, "function", children: [
-            "params", "result", "body"
+            "genericParams", "params", "result", "body"
         ]),
         .init(.decl, "import"),
         .init(.decl, "index", children: [
             "index", "value"
         ]),
         .init(.decl, "interface", children: [
-            "extends", "body"
+            "genericParams", "extends", "body"
         ]),
         .init(.decl, "method", children: [
-            "params", "result", "body"
+            "genericParams", "params", "result", "body"
         ]),
         .init(.decl, "namespace", children: [
             "body"
@@ -62,7 +62,7 @@ struct Definitions {
             "elements"
         ]),
         .init(.decl, "type", children: [
-            "type"
+            "genericParams", "type"
         ]),
         .init(.decl, "var", children: [
             "type", "initializer"
@@ -84,7 +84,7 @@ struct Definitions {
             "callee", "args"
         ]),
         .init(.expr, "closure", children: [
-            "params", "result", "body"
+            "genericParams", "params", "result", "body"
         ]),
         .init(.expr, "custom"),
         .init(.expr, "ident"),
@@ -157,7 +157,7 @@ struct Definitions {
         ]),
         .init(.type, "custom"),
         .init(.type, "function", children: [
-            "params", "result"
+            "genericParams", "params", "result"
         ]),
         .init(.type, "ident", children: [
             "genericArgs"

--- a/Tests/TypeScriptASTTests/PrintDeclTests.swift
+++ b/Tests/TypeScriptASTTests/PrintDeclTests.swift
@@ -542,4 +542,27 @@ final class PrintDeclTests: TestCaseBase {
             """
         )
     }
+
+    func testGenericTypeParameter() throws {
+        assertPrint(
+            TSTypeDecl(
+                name: "A",
+                genericParams: [
+                    .init("T"),
+                    .init("U", extends: TSObjectType([])),
+                    .init("V", default: TSIdentType.string),
+                    .init("W", extends: TSIdentType.string, default: TSIdentType.string),
+                ],
+                type: TSIdentType.never
+            ),
+            """
+            type A<
+                T,
+                U extends {},
+                V = string,
+                W extends string = string
+            > = never;
+            """
+        )
+    }
 }

--- a/Tests/TypeScriptASTTests/PrintDeclTests.swift
+++ b/Tests/TypeScriptASTTests/PrintDeclTests.swift
@@ -59,7 +59,7 @@ final class PrintDeclTests: TestCaseBase {
         assertPrint(
             TSTypeDecl(
                 name: "A",
-                genericParams: ["T"],
+                genericParams: [.init("T")],
                 type: TSIdentType("B", genericArgs: [TSIdentType("T")])
             ),
             """
@@ -200,7 +200,7 @@ final class PrintDeclTests: TestCaseBase {
             TSFunctionDecl(
                 modifiers: [.export],
                 name: "f",
-                genericParams: ["A", "B", "C", "D"],
+                genericParams: [.init("A"), .init("B"), .init("C"), .init("D")],
                 params: [
                     .init(name: "a", type: TSIdentType.number),
                     .init(name: "b", type: TSIdentType.string),
@@ -246,12 +246,12 @@ final class PrintDeclTests: TestCaseBase {
         assertPrint(
             TSInterfaceDecl(
                 name: "I",
-                genericParams: ["T"],
+                genericParams: [.init("T")],
                 extends: [TSIdentType("J")],
                 body: TSBlockStmt([
                     TSMethodDecl(
                         name: "a",
-                        genericParams: ["U"],
+                        genericParams: [.init("U")],
                         params: [.init(name: "x", type: TSIdentType("T"))],
                         result: TSIdentType("U")
                     )
@@ -268,7 +268,7 @@ final class PrintDeclTests: TestCaseBase {
             TSInterfaceDecl(
                 modifiers: [.export],
                 name: "I",
-                genericParams: ["T"],
+                genericParams: [.init("T")],
                 extends: [
                     TSIdentType("J", genericArgs: [TSIdentType("T")]),
                     TSIdentType("K")
@@ -278,7 +278,7 @@ final class PrintDeclTests: TestCaseBase {
                     TSFieldDecl(name: "y", type: TSIdentType.number),
                     TSIndexDecl(modifiers: [.readonly], name: "i", index: TSIdentType.number, value: TSIdentType.number),
                     TSMethodDecl(name: "f", params: []),
-                    TSMethodDecl(name: "g", genericParams: ["U"], params: [
+                    TSMethodDecl(name: "g", genericParams: [.init("U")], params: [
                         .init(name: "a", type: TSIdentType.string)
                     ], result: TSIdentType.string)
                 ])
@@ -309,7 +309,7 @@ final class PrintDeclTests: TestCaseBase {
             TSClassDecl(
                 modifiers: [.export],
                 name: "A",
-                genericParams: ["T"],
+                genericParams: [.init("T")],
                 extends: TSIdentType("B"),
                 implements: [TSIdentType("I")],
                 body: TSBlockStmt([
@@ -344,7 +344,7 @@ final class PrintDeclTests: TestCaseBase {
         assertPrint(
             TSClassDecl(
                 name: "A",
-                genericParams: ["T"],
+                genericParams: [.init("T")],
                 extends: TSIdentType("B", genericArgs: [TSIdentType("T")]),
                 implements: [TSIdentType("I", genericArgs: [TSIdentType("T")])],
                 body: TSBlockStmt([

--- a/Tests/TypeScriptASTTests/PrintExprTests.swift
+++ b/Tests/TypeScriptASTTests/PrintExprTests.swift
@@ -332,11 +332,11 @@ final class PrintExprTests: TestCaseBase {
         )
 
         assertPrint(
-            TSClosureExpr(genericParams: ["T"], params: [.init(name: "t", type: TSIdentType("T"))], body: TSIdentExpr("t")),
+            TSClosureExpr(genericParams: [.init("T")], params: [.init(name: "t", type: TSIdentType("T"))], body: TSIdentExpr("t")),
             "<T,>(t: T) => t"
         )
         assertPrint(
-            TSClosureExpr(genericParams: ["T", "U"], params: [.init(name: "tu", type: TSIntersectionType([
+            TSClosureExpr(genericParams: [.init("T"), .init("U")], params: [.init(name: "tu", type: TSIntersectionType([
                 TSIdentType("T"),
                 TSIdentType("U"),
             ]))], body: TSIdentExpr("tu")),

--- a/Tests/TypeScriptASTTests/PrintTypeTests.swift
+++ b/Tests/TypeScriptASTTests/PrintTypeTests.swift
@@ -183,7 +183,7 @@ final class PrintTypeTests: TestCaseBase {
                 .field(.init(name: "a", type: TSIdentType("A"))),
                 .field(.init(name: "b", isOptional: true, type: TSIdentType("B"))),
                 .method(.init(name: "c", params: [], result: TSIdentType("C"))),
-                .method(.init(name: "d", isOptional: true, genericParams: ["T"], params: [], result: TSIdentType("D"))),
+                .method(.init(name: "d", isOptional: true, genericParams: [.init("T")], params: [], result: TSIdentType("D"))),
                 .index(.init(name: "e", index: TSIdentType.number, value: TSIdentType("E"))),
             ]),
             """
@@ -232,7 +232,7 @@ final class PrintTypeTests: TestCaseBase {
             """
         )
 
-        assertPrint(TSFunctionType(genericParams: ["T"], params: [], result: TSIdentType("T")), "<T>() => T")
+        assertPrint(TSFunctionType(genericParams: [.init("T")], params: [], result: TSIdentType("T")), "<T>() => T")
     }
 
     func testCustom() throws {

--- a/Tests/TypeScriptASTTests/ScanDependencyTests.swift
+++ b/Tests/TypeScriptASTTests/ScanDependencyTests.swift
@@ -43,13 +43,13 @@ final class ScanDependencyTests: TestCaseBase {
 
     func testUseType() throws {
         let s = TSSourceFile([
-            TSTypeDecl(name: "S", genericParams: ["T"], type: TSObjectType([
+            TSTypeDecl(name: "S", genericParams: [.init("T")], type: TSObjectType([
                 .field(.init(name: "a", type: TSIdentType.string)),
                 .field(.init(name: "b", type: TSIdentType("T"))),
                 .field(.init(name: "c", type: TSIdentType("X"))),
             ])),
             TSFunctionDecl(
-                name: "f", genericParams: ["T", "U"],
+                name: "f", genericParams: [.init("T"), .init("U")],
                 params: [
                     .init(name: "t", type: TSIdentType("T")),
                     .init(name: "u", type: TSIdentType("U")),
@@ -99,7 +99,7 @@ final class ScanDependencyTests: TestCaseBase {
                 TSMethodDecl(name: "f", params: [], result: TSIdentType.void)
             ])),
             TSClassDecl(
-                name: "K", genericParams: ["T"], extends: TSIdentType("M"),
+                name: "K", genericParams: [.init("T")], extends: TSIdentType("M"),
                 implements: [TSIdentType("I"), TSIdentType("J")],
                 body: TSBlockStmt([
                     TSFieldDecl(name: "t", isOptional: true, type: TSIdentType("T")),
@@ -169,11 +169,11 @@ final class ScanDependencyTests: TestCaseBase {
     func testStruct() throws {
         let s = TSSourceFile([
             TSTypeDecl(
-                name: "X", genericParams: ["T"],
+                name: "X", genericParams: [.init("T")],
                 type: TSObjectType([])
             ),
             TSTypeDecl(
-                name: "S", genericParams: ["T", "U"],
+                name: "S", genericParams: [.init("T"), .init("U")],
                 type: TSObjectType([
                     .field(.init(name: "a", isOptional: true, type: TSIdentType("A"))),
                     .field(.init(name: "b", type: TSIdentType("number"))),
@@ -212,10 +212,10 @@ final class ScanDependencyTests: TestCaseBase {
     func testInterface() throws {
         let s = TSSourceFile([
             TSInterfaceDecl(
-                name: "I", genericParams: ["T"], extends: [TSIdentType("J")],
+                name: "I", genericParams: [.init("T")], extends: [TSIdentType("J")],
                 body: TSBlockStmt([
                     TSMethodDecl(
-                        name: "foo", genericParams: ["U"],
+                        name: "foo", genericParams: [.init("U")],
                         params: [
                             .init(name: "a", type: TSIdentType("A")),
                             .init(name: "t", type: TSIdentType("T")),
@@ -243,11 +243,11 @@ final class ScanDependencyTests: TestCaseBase {
     func testClass() throws {
         let s = TSSourceFile([
             TSClassDecl(
-                name: "C", genericParams: ["T"],
+                name: "C", genericParams: [.init("T")],
                 extends: TSIdentType("D"), implements: [TSIdentType("I")],
                 body: TSBlockStmt([
                     TSMethodDecl(
-                        name: "foo", genericParams: ["U"],
+                        name: "foo", genericParams: [.init("U")],
                         params: [
                             .init(name: "a", type: TSIdentType("A")),
                             .init(name: "t", type: TSIdentType("T")),
@@ -391,7 +391,7 @@ final class ScanDependencyTests: TestCaseBase {
         let s = TSSourceFile([
             TSTypeDecl(name: "t", type: TSObjectType([
                 .field(.init(name: "f", type: TSFunctionType(
-                    genericParams: ["T"],
+                    genericParams: [.init("T")],
                     params: [.init(name: "a", type: TSIdentType("A"))],
                     result: TSIdentType("T")
                 ))),
@@ -416,7 +416,7 @@ final class ScanDependencyTests: TestCaseBase {
                 kind: .const,
                 name: "f",
                 initializer: TSClosureExpr(
-                    genericParams: ["T"],
+                    genericParams: [.init("T")],
                     params: [.init(name: "tu", type: TSIntersectionType([
                         TSIdentType("T"),
                         TSIdentType("U"),
@@ -440,7 +440,7 @@ final class ScanDependencyTests: TestCaseBase {
         let s = TSSourceFile([
             TSTypeDecl(
                 name: "F",
-                genericParams: ["T"],
+                genericParams: [.init("T")],
                 type: TSConditionalType(
                     TSIdentType("T"),
                     extends: TSArrayType(TSInferType(name: "I")),
@@ -464,7 +464,7 @@ final class ScanDependencyTests: TestCaseBase {
         let s = TSSourceFile([
             TSTypeDecl(
                 name: "F",
-                genericParams: ["T"],
+                genericParams: [.init("T")],
                 type: TSConditionalType(
                     TSIdentType("T"),
                     extends: TSArrayType(TSInferType(name: "I")),
@@ -488,7 +488,7 @@ final class ScanDependencyTests: TestCaseBase {
         let s = TSSourceFile([
             TSTypeDecl(
                 name: "E",
-                genericParams: ["T"],
+                genericParams: [.init("T")],
                 type: TSMappedType(
                     "P",
                     in: TSKeyofType(TSIdentType("T")),

--- a/Tests/TypeScriptASTTests/ScanDependencyTests.swift
+++ b/Tests/TypeScriptASTTests/ScanDependencyTests.swift
@@ -509,4 +509,26 @@ final class ScanDependencyTests: TestCaseBase {
 
         XCTAssertEqual(Set(s.scanDependency()), ["Exclude"])
     }
+
+    func testGenericTypeParameter() {
+        let s = TSSourceFile([
+            TSTypeDecl(
+                name: "A", genericParams: [
+                    .init("T"),
+                    .init("U", extends: TSUnionType([TSIdentType("T"),  TSIdentType("V"), TSIdentType("B")])),
+                    .init("V", default: TSIdentType("C")),
+                ],
+                type: TSIdentType("T")
+            ),
+        ])
+
+        assertPrint(
+            s, """
+            type A<T, U extends T | V | B, V = C> = T;
+
+            """
+        )
+
+        XCTAssertEqual(Set(s.scanDependency()), ["B", "C"])
+    }
 }


### PR DESCRIPTION
ジェネリック型パラメータに `extends` やデフォルト値を書けるようにします。

例: 

```ts
type A<
    T,
    U extends {},
    V = string,
    W extends string = string
> = never;
```

これに伴って `TSTypeParameterNode` が追加されました。
今まで `genericParams: [String]` で受け取っていた部分が `[TSTypeParameterNode]` に変化します。

`TSTypeParameterNode` は既存のexpr, stmt, type, declのどれに属するべきか悩ましかったので特に何にも属しないnodeにしています。
extendsやデフォルト値として利用される型はASTNodeとしてvisitされてほしいので、型パラを表すクラスもASTNodeである必要があります。

`TSTypeParameterNode` に類似する存在として、`TSFunctionType.Param` 及び `TSObjectExpr.Field` があります。
それらはその内部にASTNodeを含みますが、それらを持つNode自体が`setParent`を手作業で操作することで、それら自身はASTNodeではないにも関わらずツリー構造を保っています。

これと同じことを `[TSTypeParameterNode]` でやろうとすると、利用箇所が多いのでボイラープレートが増えそうです。