### PR TITLE
Add spread option to function parameter

### DIFF
--- a/Sources/ASTNodeModule/Type/TSFunctionType.swift
+++ b/Sources/ASTNodeModule/Type/TSFunctionType.swift
@@ -1,15 +1,18 @@
 public final class TSFunctionType: _TSType {
     public struct Param {
         public init(
+            spread: Bool = false,
             name: String,
             isOptional: Bool = false,
             type: (any TSType)? = nil
         ) {
+            self.spread = spread
             self.name = name
             self.isOptional = isOptional
             self.type = type
         }
 
+        public var spread: Bool
         public var name: String
         public var isOptional: Bool
         public var type: (any TSType)?

--- a/Sources/TypeScriptAST/Printer/ASTPrinter.swift
+++ b/Sources/TypeScriptAST/Printer/ASTPrinter.swift
@@ -827,6 +827,9 @@ public final class ASTPrinter: ASTVisitor {
     }
 
     private func write(param: TSFunctionType.Param) {
+        if param.spread {
+            printer.write("...")
+        }
         printer.write(param.name)
         if let type = param.type {
             if param.isOptional {

--- a/Tests/TypeScriptASTTests/PrintDeclTests.swift
+++ b/Tests/TypeScriptASTTests/PrintDeclTests.swift
@@ -181,7 +181,7 @@ final class PrintDeclTests: TestCaseBase {
                 name: "f",
                 params: [
                     .init(name: "a", type: TSIdentType.number),
-                    .init(name: "b", type: TSIdentType.string)
+                    .init(spread: true, name: "b", type: TSArrayType(TSIdentType.string))
                 ],
                 body: TSBlockStmt([
                     TSReturnStmt(
@@ -190,7 +190,7 @@ final class PrintDeclTests: TestCaseBase {
                 ])
             ),
             """
-            export function f(a: number, b: string) {
+            export function f(a: number, ...b: string[]) {
                 return 0;
             }
             """


### PR DESCRIPTION
関数の引数でスプレッド演算子を利用できるようにします

```ts
function sum(...numbers: Array<number>): number {
  return numbers.reduce((a, b) => a + b, 0);
}
```