### PR TITLE
import生成の時に拡張子を調整する

### DIFF
--- a/Sources/TypeScriptAST/Dependency/ImportFileExtension.swift
+++ b/Sources/TypeScriptAST/Dependency/ImportFileExtension.swift
@@ -1,0 +1,4 @@
+public enum ImportFileExtension {
+    case none
+    case js
+}


### PR DESCRIPTION
commonjsでは拡張子無し、
esnextでは `.js` にするのが良いっぽい

これをユーザーが選択できるようにする