### PR TITLE
完全なパスを使う事にする

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -53,15 +53,6 @@
         "revision" : "4f07be3dc201f6e2ee85b6942d0c220a16926811",
         "version" : "0.2.7"
       }
-    },
-    {
-      "identity" : "swiftyrelativepath",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/neoneye/SwiftyRelativePath",
-      "state" : {
-        "revision" : "36c56e0b3269d58ee46ced1eef797ca2bd65a818",
-        "version" : "1.0.0"
-      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/omochi/CodegenKit", from: "1.1.3"),
-        .package(url: "https://github.com/neoneye/SwiftyRelativePath", from: "1.0.0")
+        .package(url: "https://github.com/omochi/CodegenKit", from: "1.1.3")
     ],
     targets: [
         .executableTarget(
@@ -38,8 +37,7 @@ let package = Package(
         .target(
             name: "TypeScriptAST",
             dependencies: [
-                .target(name: "ASTNodeModule"),
-                .product(name: "SwiftyRelativePath", package: "SwiftyRelativePath")
+                .target(name: "ASTNodeModule")
             ]
         ),
         .testTarget(

--- a/Sources/TypeScriptAST/Component/RelativePath.swift
+++ b/Sources/TypeScriptAST/Component/RelativePath.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+extension URL {
+    /*
+     Modified implementation of
+     https://github.com/neoneye/SwiftyRelativePath
+     */
+    public func relativePath(from originalFrom: URL) -> URL {
+        let dest = self.absoluteURL.standardized.pathComponents
+        let from = originalFrom.absoluteURL.standardized.pathComponents
+
+        var i = 0
+        while i < dest.count,
+              i < from.count,
+              dest[i] == from[i]
+        {
+            i += 1
+        }
+
+        var rel = Array(repeating: "..", count: from.count - i)
+        rel.append(contentsOf: dest[i...])
+        return URL(
+            fileURLWithPath: rel.joined(separator: "/"),
+            relativeTo: originalFrom
+        )
+    }
+}
+

--- a/Sources/TypeScriptAST/Component/SymbolTable.swift
+++ b/Sources/TypeScriptAST/Component/SymbolTable.swift
@@ -1,7 +1,9 @@
+import Foundation
+
 public struct SymbolTable {
     public enum File {
         case standardLibrary
-        case file(String)
+        case file(URL)
     }
 
     public init(
@@ -61,7 +63,7 @@ public struct SymbolTable {
         table[symbol] = file
     }
 
-    public mutating func add(source: TSSourceFile, file: String) {
+    public mutating func add(source: TSSourceFile, file: URL) {
         for symbol in source.memberDeclaredNames {
             add(symbol: symbol, file: .file(file))
         }

--- a/Tests/TypeScriptASTTests/AutoImportTests.swift
+++ b/Tests/TypeScriptASTTests/AutoImportTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import TypeScriptAST
 
@@ -34,10 +35,10 @@ final class AutoImportTests: TestCaseBase {
         )
 
         var symbols = SymbolTable()
-        symbols.add(source: s, file: "s.ts")
+        symbols.add(source: s, file: URL(fileURLWithPath: "s.ts"))
 
         let imports = try m.buildAutoImportDecls(
-            from: "m.ts",
+            from: URL(fileURLWithPath: "m.ts"),
             symbolTable: symbols,
             fileExtension: .js
         )
@@ -89,10 +90,10 @@ final class AutoImportTests: TestCaseBase {
         )
 
         var symbols = SymbolTable()
-        symbols.add(source: s, file: "s.ts")
+        symbols.add(source: s, file: URL(fileURLWithPath: "s.ts"))
 
         let imports = try m.buildAutoImportDecls(
-            from: "m.ts",
+            from: URL(fileURLWithPath: "m.ts"),
             symbolTable: symbols,
             fileExtension: .none
         )
@@ -118,10 +119,10 @@ final class AutoImportTests: TestCaseBase {
         ])
 
         var symbols = SymbolTable()
-        symbols.add(source: s, file: "s/s.ts")
+        symbols.add(source: s, file: URL(fileURLWithPath: "s/s.ts"))
 
         let imports = try m.buildAutoImportDecls(
-            from: "s/m.ts",
+            from: URL(fileURLWithPath: "s/m.ts"),
             symbolTable: symbols,
             fileExtension: .none
         )
@@ -147,10 +148,10 @@ final class AutoImportTests: TestCaseBase {
         ])
 
         var symbols = SymbolTable()
-        symbols.add(source: s, file: "s/s/s.ts")
+        symbols.add(source: s, file: URL(fileURLWithPath: "s/s/s.ts"))
 
         let imports = try m.buildAutoImportDecls(
-            from: "s/m.ts",
+            from: URL(fileURLWithPath: "s/m.ts"),
             symbolTable: symbols,
             fileExtension: .none
         )
@@ -176,10 +177,10 @@ final class AutoImportTests: TestCaseBase {
         ])
 
         var symbols = SymbolTable()
-        symbols.add(source: s, file: "s/s.ts")
+        symbols.add(source: s, file: URL(fileURLWithPath: "s/s.ts"))
 
         let imports = try m.buildAutoImportDecls(
-            from: "m/m.ts",
+            from: URL(fileURLWithPath: "m/m.ts"),
             symbolTable: symbols,
             fileExtension: .none
         )
@@ -211,7 +212,7 @@ final class AutoImportTests: TestCaseBase {
         )
 
         let imports = try s.buildAutoImportDecls(
-            from: "s.ts",
+            from: URL(fileURLWithPath: "s.ts"),
             symbolTable: SymbolTable(),
             fileExtension: .js,
             defaultFile: ".."


### PR DESCRIPTION
特定のディレクトリから切り離した相対パスを考えるようにしていたが、
外部参照の解決を考えると、
何らかのフルパスを考えられる相対パスとして扱ったほうが良かった
その場合 `URL` 型が適切