### PR TITLE
Display all unknown symbols

### DIFF
--- a/Sources/TypeScriptAST/Dependency/AutoImport.swift
+++ b/Sources/TypeScriptAST/Dependency/AutoImport.swift
@@ -29,6 +29,7 @@ extension TSSourceFile {
         }
 
         let symbols = self.scanDependency()
+        var unknownSymbols: Set<String> = []
         for symbol in symbols {
             if originalSymbols.contains(symbol) {
                 continue
@@ -51,8 +52,11 @@ extension TSSourceFile {
                 fileToSymbols.add(file: defaultFile, symbol: symbol)
                 continue
             } else {
-                throw MessageError("unknown symbol: \(symbol)")
+                unknownSymbols.insert(symbol)
             }
+        }
+        if !unknownSymbols.isEmpty {
+            throw MessageError("unknown symbols: \(unknownSymbols.sorted().joined(separator: ", "))")
         }
 
         var imports: [TSImportDecl] = []

--- a/Tests/TypeScriptASTTests/AutoImportTests.swift
+++ b/Tests/TypeScriptASTTests/AutoImportTests.swift
@@ -228,4 +228,28 @@ final class AutoImportTests: TestCaseBase {
             """
         )
     }
+
+    func testUnknownSymbols() throws {
+        let s = TSSourceFile([
+            TSVarDecl(
+                kind: .const, name: "a", type: TSIdentType("A"),
+                initializer: TSIdentExpr("b")
+            )
+        ])
+
+        assertPrint(
+            s, """
+            const a: A = b;
+
+            """
+        )
+
+        XCTAssertThrowsError(try s.buildAutoImportDecls(
+            from: URL(fileURLWithPath: "s.ts"),
+            symbolTable: SymbolTable(),
+            fileExtension: .js
+        )) { error in
+            XCTAssertEqual("\(error)", "unknown symbols: A, b")
+        }
+    }
 }


### PR DESCRIPTION
細かい修正です。
`buildAutoImportDecls`において未知のシンボルが検出されたときのエラーをより親切にします。

見つからなかったシンボルを全て出力できるようにします。