### PR TITLE
Swift6のFoundationのバグを回避する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: swift-actions/setup-swift@v1
         with:
-          swift-version: "5.7"
+          swift-version: "5.10.1"
       - uses: actions/checkout@v3
       - run: swift package resolve
       - run: swift build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: swift-actions/setup-swift@v1
+      - uses: swift-actions/setup-swift@v2
         with:
           swift-version: "5.10.1"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: swift package resolve
       - run: swift build
       - run: swift test

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "codegenkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/omochi/CodegenKit",
+      "location" : "https://github.com/omochi/CodegenKit.git",
       "state" : {
         "revision" : "ab5ad508aab30b1572caa6e73ac0206611db0b0d",
         "version" : "2.0.0"
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-cmark.git",
       "state" : {
-        "revision" : "3bc2f3e25df0cecc5dc269f7ccae65d0f386f06a",
-        "version" : "0.4.0"
+        "revision" : "3ccff77b2dc5b96b77db3da0d68d28068593fa53",
+        "version" : "0.5.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-markdown.git",
       "state" : {
-        "revision" : "4aae40bf6fff5286e0e1672329d17824ce16e081",
-        "version" : "0.4.0"
+        "revision" : "8f79cb175981458a0a27e76cb42fee8e17b1a993",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.8
 
 import PackageDescription
 

--- a/Sources/TypeScriptAST/Basic/URLs.swift
+++ b/Sources/TypeScriptAST/Basic/URLs.swift
@@ -5,9 +5,9 @@ public enum URLs {
      Modified implementation of
      https://github.com/neoneye/SwiftyRelativePath
      */
-    public static func relativePath(to dest: URL, from originalFrom: URL) -> URL {
-        let dest = dest.absoluteURL.standardized.pathComponents
-        let from = originalFrom.absoluteURL.standardized.pathComponents
+    public static func relativePath(to destURL: URL, from fromURL: URL) -> URL {
+        let dest = destURL.absoluteURL.standardized.pathComponents
+        let from = fromURL.absoluteURL.standardized.pathComponents
 
         var i = 0
         while i < dest.count,
@@ -21,12 +21,17 @@ public enum URLs {
         rel.append(contentsOf: dest[i...])
         return URL(
             fileURLWithPath: rel.joined(separator: "/"),
-            relativeTo: originalFrom
+            relativeTo: fromURL
         )
     }
 
     public static func replacingPathExtension(of url: URL, to ext: String) -> URL {
-        let dir = url.deletingLastPathComponent()
+        var dir = url.deletingLastPathComponent()
+        if dir.relativePath == "" {
+            // swift-foundation のバグを回避する
+            dir = URL(fileURLWithPath: ".", isDirectory: true, relativeTo: dir.baseURL)
+        }
+
         var base = url.lastPathComponent
         let stem = (base as NSString).deletingPathExtension
         base = stem
@@ -34,10 +39,18 @@ public enum URLs {
             base += "." + ext
         }
         if dir.relativePath == "." {
+            /*
+             元の relativePath が foo.ts のような単体ファイル名だった場合、
+             appendすると ./foo.ts に変化してしまう。
+             これを防ぐために init を使う。
+             */
             return URL(fileURLWithPath: base, relativeTo: url.baseURL)
-        } else {
-            return dir.appendingPathComponent(base)
         }
+
+        /*
+         元の relativePath が絶対パスでも相対パスでもそれを維持するために、init ではなく append を使う.
+         */
+        return dir.appendingPathComponent(base)
     }
 }
 

--- a/Tests/TypeScriptASTTests/UtilsTests.swift
+++ b/Tests/TypeScriptASTTests/UtilsTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import TypeScriptAST
+
+final class UtilsTests: XCTestCase {
+    func testReplaceExtension() throws {
+        let work = URL(fileURLWithPath: "/work", isDirectory: true)
+
+        do {
+            let u = URLs.replacingPathExtension(of: URL(fileURLWithPath: "a.swift", relativeTo: work), to: "ts")
+            XCTAssertEqual(u.relativePath, "a.ts")
+            XCTAssertEqual(u.path, "/work/a.ts")
+            XCTAssertEqual(u.baseURL?.path, "/work")
+        }
+
+        do {
+            let u = URLs.replacingPathExtension(of: URL(fileURLWithPath: "dir/a.swift", relativeTo: work), to: "ts")
+            XCTAssertEqual(u.relativePath, "dir/a.ts")
+            XCTAssertEqual(u.path, "/work/dir/a.ts")
+            XCTAssertEqual(u.baseURL?.path, "/work")
+        }
+
+        do {
+            let u = URLs.replacingPathExtension(of: URL(fileURLWithPath: "../a.swift", relativeTo: work), to: "ts")
+            XCTAssertEqual(u.relativePath, "../a.ts")
+            XCTAssertEqual(u.path, "/a.ts")
+            XCTAssertEqual(u.baseURL?.path, "/work")
+        }
+
+        do {
+            let u = URLs.replacingPathExtension(of: URL(fileURLWithPath: "/work/a.swift"), to: "ts")
+            XCTAssertEqual(u.relativePath, "/work/a.ts")
+            XCTAssertEqual(u.path, "/work/a.ts")
+            XCTAssertNil(u.baseURL)
+        }
+
+        do {
+            let u = URLs.replacingPathExtension(of: URL(fileURLWithPath: "/work/dir/a.swift"), to: "ts")
+            XCTAssertEqual(u.relativePath, "/work/dir/a.ts")
+            XCTAssertEqual(u.path, "/work/dir/a.ts")
+            XCTAssertNil(u.baseURL)
+        }
+    }
+}


### PR DESCRIPTION
Swift 6 から Linux 向けに配布されている `Foundation.URL` にバグがあり、
動作が壊れるので、それを回避するパッチ

バグの詳細はこちら
https://discord.com/channels/291054398077927425/430242233468452865/1285805179610075197

`URL` の複雑な仕様についてはこちらにも書いた。
https://github.com/omochi/CodableToTypeScript/pull/126