### PR TITLE
パーサを作る

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,14 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "5.10.1"
       - uses: actions/checkout@v4
+
+      - run: sudo $GITHUB_WORKSPACE/ci/install-swift.bash
+        working-directory: /home/runner
+      - run: swift --version
+
       - run: swift package resolve
       - run: swift build
       - run: swift test

--- a/Sources/TypeScriptAST/Parser/CharacterEx.swift
+++ b/Sources/TypeScriptAST/Parser/CharacterEx.swift
@@ -1,0 +1,14 @@
+extension Character {
+    static let a = Character("a")
+    static let z = Character("z")
+    static let A = Character("A")
+    static let Z = Character("Z")
+    static let _0 = Character("0")
+    static let _9 = Character("9")
+    static let underscore = Character("_")
+    static let space = Character(" ")
+    static let tab = Character("\t")
+    static let lf = Character("\n")
+    static let cr = Character("\r")
+    static let crlf = Character("\r\n")
+}

--- a/Sources/TypeScriptAST/Parser/Keyword.swift
+++ b/Sources/TypeScriptAST/Parser/Keyword.swift
@@ -1,0 +1,4 @@
+public enum Keyword: String, Equatable {
+    case `import`
+    case from
+}

--- a/Sources/TypeScriptAST/Parser/Parser.swift
+++ b/Sources/TypeScriptAST/Parser/Parser.swift
@@ -1,0 +1,3 @@
+public struct Parser {
+    
+}

--- a/Sources/TypeScriptAST/Parser/Token.swift
+++ b/Sources/TypeScriptAST/Parser/Token.swift
@@ -1,0 +1,5 @@
+public enum Token: Equatable {
+    case keyword(Keyword)
+    case identifier(String)
+}
+

--- a/Sources/TypeScriptAST/Parser/Tokenizer.swift
+++ b/Sources/TypeScriptAST/Parser/Tokenizer.swift
@@ -1,0 +1,104 @@
+public struct Tokenizer {
+    public init(
+        string: String,
+        position: String.Index? = nil
+    ) {
+        self.string = string
+        self.pos = position ?? string.startIndex
+        self.nextToken = nil
+        _ = self.read()
+    }
+
+    public let string: String
+    public var position: String.Index {
+        get { pos }
+        set {
+            pos = newValue
+            nextToken = nil
+            _ = read()
+        }
+    }
+    private var pos: String.Index
+
+    public private(set) var nextToken: Token?
+
+    public mutating func read() -> Token? {
+        let result = nextToken
+        nextToken = readNextToken()
+        return result
+    }
+
+    public mutating func readAll() -> [Token] {
+        var result: [Token] = []
+        while let token = read() {
+            result.append(token)
+        }
+        return result
+    }
+
+    private mutating func readNextToken() -> Token? {
+        while true {
+            guard let c = char(at: pos) else { return nil }
+
+            if isWhitespace(c) {
+                readWhitespace()
+                continue
+            }
+
+            if isKeyword(c) {
+                return readKeyword()
+            }
+
+            pos = string.index(after: pos)
+        }
+    }
+
+    private mutating func readWhitespace() {
+        _ = readString(where: isWhitespace)
+    }
+
+    private mutating func readKeyword() -> Token {
+        let s = readKeywordString()
+        if let k = Keyword(rawValue: s) {
+            return .keyword(k)
+        }
+        return .identifier(s)
+    }
+
+    private mutating func readKeywordString() -> String {
+        readString(where: isKeyword)
+    }
+
+    private mutating func readString(where predicate: (Character) -> Bool) -> String {
+        let start = pos
+        while true {
+            if let c = char(at: pos), predicate(c) {
+                pos = string.index(after: pos)
+                continue
+            }
+            return String(string[start..<pos])
+        }
+    }
+
+    private func isWhitespace(_ c: Character) -> Bool {
+        switch c {
+        case .space, .tab, .lf, .cr, .crlf: return true
+        default: return false
+        }
+    }
+
+    private func isKeyword(_ c: Character) -> Bool {
+        switch c {
+        case .a ... .z,
+                .A ... .Z,
+                ._0 ... ._9,
+                .underscore: return true
+        default: return false
+        }
+    }
+
+    private func char(at index: String.Index) -> Character? {
+        if index == string.endIndex { return nil }
+        return string[index]
+    }
+}

--- a/Tests/TypeScriptASTTests/TokenizerTests.swift
+++ b/Tests/TypeScriptASTTests/TokenizerTests.swift
@@ -1,0 +1,18 @@
+import Testing
+import TypeScriptAST
+
+@Suite struct TokenizerTests {
+    static var data: [(String, [Token])] {
+        let result: [(String, [Token])] = [
+            ("", []),
+            ("import from", [Token.keyword(.import), .keyword(.from)]),
+        ]
+        return result
+    }
+
+    @Test(arguments: Self.data) func test(string: String, expected: [Token]) {
+        var k  = Tokenizer(string: string)
+        let ts = k.readAll()
+        #expect(ts == expected)
+    }
+}

--- a/ci/install-swift.bash
+++ b/ci/install-swift.bash
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -ue
+
+dir=swift-6.0.2-release/ubuntu2204
+version=swift-6.0.2-RELEASE
+tar_platform=ubuntu22.04
+
+if [[ $(uname -m) == "aarch64" ]]; then
+    dir=${dir}-aarch64
+    tar_platform=${tar_platform}-aarch64
+fi
+
+url="https://download.swift.org/${dir}/${version}/${version}-${tar_platform}.tar.gz"
+
+set -x
+curl -fLo swift.tar.gz ${url}
+tar -xf swift.tar.gz --strip-components=2 -C /usr
+rm swift.tar.gz


### PR DESCRIPTION
- #9

標準ライブラリをASTではなくコードで生成できて見やすい
既存のTSコードを参照させるときにシンボル情報を外から与える必要がなくなる
